### PR TITLE
update orthography with more information

### DIFF
--- a/etc/orthography.tsv
+++ b/etc/orthography.tsv
@@ -1,1209 +1,1209 @@
-Grapheme	Graphemes	IPA	Frequency
-^	NULL	NULL	29296
-y	y	j	3602
-ė	ė	ə	3654
-+	+	+	21760
-f	f	f	2914
-ā	ā	aː	1767
-$	NULL	NULL	29760
-ĭ	ĭ	ɪ	1745
-ṑ	ṑ	ɔː	475
-aͦ̄	aͦ̄	ɒː	585
-éi̱	éi̱	ei	127
-ā́	ā́	ɑː	583
-è	è	ɛ	2846
-ṓ	ṓ	oː	509
-é	é	e	1125
-ĕ	ĕ	e	806
-i	i	i	1372
-ë	ë	ɛ	541
-e	e	e	283
-eͥ	eͥ	e	232
-ĕ́i̱	ĕ́i̱	ei	89
-ḗ	ḗ	eː	943
-ï	ï	ɪ	161
-ṯ	ṯ	t	32
-ĕ́	ĕ́	e	353
-a͜ó	a͜ó	ao	69
-ăó	ăó	ao	1
-aͦ͜ó	aͦ͜ó	ɒo	5
-a	a	a	6526
-ĕ̀	ĕ̀	ɛ	4361
-ḕ	ḕ	ɛː	989
-aͤ	aͤ	æ	532
-aͤ̄	aͤ̄	æː	675
-ts	ts	ts	1795
-ŏ́	ŏ́	o	164
-b	b	b	2073
-è̃ĩ̱	è̃ĩ̱	ɛ̃i	302
-ṣ	ṣ	θ	528
-ó	ó	o	487
-oͮ	oͮ	o	118
-ŏ̀	ŏ̀	ɔ	1855
-ō	ō	oː	111
-t	t	t	4667
-tṣ	tṣ	tθ	4
-oʋ̱	oʋ̱	ou	12
-tc̵	tc̵	tʃ	911
-óʋ̱	óʋ̱	ou	33
-ĩ	ĩ	ɪ̃	97
-òʋ	òꭒ	ɔu	21
-w	w	w	1756
-v	v	v	3962
-ē	ē	eː	297
-v̱	v̱	vː	119
-è̃i̱	è̃i̱	ɛ̃i	3
-ắ	ắ	ɑ	142
-ắè̱	ắè̱	ɑɛ	4
-ĕ̀i̱	ĕ̀i̱	ɛi	10
-aͦ̃	aͦ̃	ɑ	108
-ă	ă	a	4338
-ei̱	ei̱	ei	135
-ăè̱	ăè̱	aɛ	17
-aͤé̱	aͤé̱	æe	3
-aͤi̱	aͤi̱	æi	69
-ĕi̱	ĕi̱	ei	25
-k	k	k	3192
-ç̱̑	ç̱̑	ç	44
-eé̱	eé̱	eː	1
-ă͜è̱	ă͜è̱	aɛ	3
-ằ	ằ	a	378
-a͜é	a͜é	ae	61
-ẅ	ẅ	ɥ	221
-d	d	d	6521
-j	j	ʒ	977
-ʋ̆	ʋ̆	u	1322
-ḏ	ḏ	d	5
-œ	œ	ø	60
-ã	ã	ã	1842
-ŭ	ŭ	y	551
-ò	ò	ɔ	665
-y̱	y̱	j	278
-o	o	o	104
-œ́	œ́	ø	299
-ẖ	ẖ	h	41
-œu̱	œu̱	øy	113
-tç̑	tç̑	cç	116
-ṉ̇	ṉ̇	ŋ	336
-t̮	t̮	tʲ	398
-œ̄	œ̄	øː	105
-œ̄̀	œ̄̀	œː	53
-œ̆̀	œ̆̀	œ	296
-l	l	l	8601
-s	s	s	3455
--	-	NULL	409
-l̆̍	l̆̍	lʲ	68
-l̮	l̮	ʎ	1218
-ò̃	ò̃	ɔ̃	2287
-õ	õ	õ	96
-ṉ	ṉ	n	221
-ė̱ò̃	ė̱ò̃	əɔ̃	21
-ʋ̱̃	ʋ̱̃	ũ	2
-ò̃ʋ̱̃	ò̃ʋ̱̃	ɔ̃u	6
-ó̃	ó̃	õ	151
-ʋ̃	ʋ̃	ũ	57
-ʋ̀̃	ʋ̀̃	ʊ̃	105
-ì̃	ì̃	ɪ̃	73
-è̃	è̃	ɛ̃	1357
-ã͜ẽ̱ĩ̱	ã͜ẽ̱ ĩ̱	ãẽ ɪ̃	1
-ã̱ó̃	ã̱ó̃	aõ	2
-ù̃	ù̃	ỹ	14
-aͤ̆	aͤ̆	æ	309
-œ̀̃	œ̀̃	œ̃	70
-è̄̃	è̄̃	ɛ̃ː	137
-è̃͜ĩ̱	è̃͜ĩ̱	ɛ̃ɪ̃	1
-è̃è̱	è̃è̱	ɛ̃ɛ	1
-ẽ	ẽ	ẽ	28
-aͤ̃	aͤ̃	æ̃	116
-é̃ĩ̱	é̃ĩ̱	ẽi	83
-āè̱	āè̱	aːɛ	231
-aͦ̄è̱	aͦ̄è̱	ɒːɛ	67
-aͤ̄è̱	aͤ̄è̱	æːɛ	4
-á̃	á̃	ã	61
-n	n	n	4265
-ʋ̆̀	ʋ̆̀	ʊ	85
-ŏ	ŏ	o	373
-n̄	n̄	nː	132
-ʋ̇	ʋ̇	ʊ	51
-ʋ	ꭒ	u	503
-a̱	a̱	a	843
-ȯ	ȯ	ɔ	181
-w̱	w̱	w	141
-à	à	a	32
-ʋ̩̆	ʋ̩̆	u	47
-ă̩	ă̩	a	148
-z	z	z	968
-a͜eͥ	a͜eͥ	ae	1
-a̱aͤ̄	a̱aͤ̄	aæː	3
-c̵	c̵	ʃ	1194
-èi	èi	ɛi	27
-c̵̾	c̵̾	ʃ	357
-j͛	j͛	ʒ	163
-ī	ī	iː	1060
-ĕ́i	ĕ́i	ei	14
-éi	éi	ei	9
-āė̱	āė̱	aːə	8
-ãõ̱	ãõ̱	ão	5
-ā̀	ā̀	aː	217
-p	p	p	4479
-ç̑	ç̑	ç	564
-ū	ū	yː	200
-œ̄́	œ̄́	øː	275
-u	u	y	430
-aȯ̱	aȯ̱	aɔ	2
-āȯ̱	āȯ̱	aːɔ	4
-y̆	y̆	ʝ	12
-aͤ͜ŏ́	aͤ͜ŏ́	æo	1
-ṣ̍	ṣ̍	θˡ	31
-a͜o	a͜o	ao	14
-a͜ʋ̀	a͜ʋ̀	aʊ	2
-ȧʋ̱	ȧʋ̱	ɐu	50
-œͦ̆ʋ̱ͧ	œͦ̆ʋ̱ͧ	ɞʉ	28
-œ̆̀ʋͧ	œ̆̀ʋͧ	œʉ	1
-pf	pf	pf	7
-ʋͧ	ʋͧ	ʉ	36
-ḏz	ḏz	dz	52
-e̱ͥ	e̱ͥ	e	87
-ʋ̄	ʋ̄	uː	622
-ŏ̩̀	ŏ̩̀	ɔ	101
-ā̀o̱	ā̀o̱	aːo	2
-œ̆́	œ̆́	ø	28
-k̮	k̮	kʲ	49
-k̮ͭ	k̮ͭ	c	32
-ė̱	ė̱	ə	1765
-œ̀	œ̀	œ	62
-ë̱	ë̱	ɛ	191
-è̱	è̱	e	1291
-aͦ	aͦ	ɒ	103
-^dz	^dz	dz	289
-r	r	r	9314
-ẓ	ẓ	ð	255
-ṟ	ṟ	r	131
-œ̆	œ̆	ø	34
-œͦ̆	œͦ̆	ɞ	27
-^dj͛ẅaͤ	dj͛ ẅ aͤ	dʒ ɥ æ	1
-^dj	dj	dʒ	167
-ḗè̱	ḗè̱	eːɛ	14
-ī̀	ī̀	ɪː	46
-īė̱	īė̱	iːə	246
-iė̱	iė̱	iə	7
-īë̱	īë̱	iːɛ	74
-a͜è	a͜è	aɛ	112
-ā́è̱	ā́è̱	ɑːɛ	113
-ā̀è̱	ā̀è̱	aːɛ	8
-aͤ̄i̱	aͤ̄i̱	æːi	6
-aͤĭ	aͤĭ	æɪ	1
-āi̱	āi̱	aːi	17
-aͤi	aͤi	æi	86
-·	·		53
-ī̩è	ī̩è	iːɛ	2
-ḵ	ḵ	k	45
-a͜é̱	a͜é̱	ae	40
-āé̱	āé̱	aːe	19
-n̮	n̮	ɲ	410
-ʋ̄̀	ʋ̄̀	ʊː	32
-èė̱	èė̱	ɛə	13
-oͮʋ̱	oͮʋ̱	ou	9
-ŏ́ʋ	ŏ́ꭒ	ou	4
-aͦó̱	aͦó̱	ɒo	2
-ʋ̱	ʋ̱	u	238
-ā̩	ā̩	aː	34
-a͜ʋ̆	a͜ʋ̆	au	3
-ʋ̄œ̱̃	ʋ̄œ̱̃	uːø	1
-ṙ	ṙ	ʀ	352
-ï̱	ï̱	ɪ	10
-aͦ͜ó̱	aͦ͜ó̱	ɒo	3
-a̱ḕ	a̱ḕ	aɛː	32
-ă͜è	ă͜è	aɛ	1
-a͜aͤ	a͜aͤ	aæ	1
-aͤ̆i	aͤ̆i	æi	13
-ī̩è̱	ī̩è̱	iːɛ	13
-ĕ̩̀	ĕ̩̀	ɛ	209
-ăé̱	ăé̱	ae	9
-a͜aͤ̄	a͜aͤ̄	aæː	1
-aè̱	aè̱	aɛ	32
-aͤ̆i̱	aͤ̆i̱	æi	13
-aͤ̄i	aͤ̄i	æːi	1
-ā̀e̱	ā̀e̱	aːe	28
-aé̱	aé̱	ae	17
-aͦ̄ė̱	aͦ̄ė̱	ɒːə	2
-ā́ė̱	ā́ė̱	ɑːə	6
-m	m	m	3434
-ã̱è̃	ã̱è̃	aɛ̃	11
-ė̃	ė̃	ə̃	53
-āe̱ͥ	āe̱ͥ	aːe	3
-ī̩	ī̩	iː	34
-h	h	h	73
-ṛ	ṛ	ɾ	23
-aè	aè	aɛ	30
-ḕi̱	ḕi̱	ɛːi	6
-a͜ē̩	a͜ē̩	aeː	1
-ai̱	ai̱	ai	16
-d̄	d̄	dː	6
-ằi̱	ằi̱	ai	2
-i̱	i̱	i	39
-a̩ͤ̄	a̩ͤ̄	æː	14
-āè	āè	aːɛ	21
-ei	ei	ei	30
-ēè̱	ēè̱	eːɛ	4
-aͤ̄ï̱	aͤ̄ï̱	æːɪ	1
-a͜ḗ̩	a͜ḗ̩	aeː	1
-e̱	e̱	e	122
-ā́ë̱	ā́ë̱	ɑːɛ	1
-āe̱	āe̱	aːe	10
-dz	dz	dz	923
-ăŏ́	ăŏ́	ao	2
-i̩	i̩	ɪ	23
-ṑó̱	ṑó̱	ɔːo	10
-á	á	ɑ	54
-œ̱ò̃	œ̱ò̃	øɔ̃	4
-a̩ó̱	a̩ó̱	ao	2
-a͜ó̩	a͜ó̩	ao	3
-dẓ	dẓ	dð	3
-áò̱	áò̱	ɑɔ	4
-aò̱	aò̱	aɔ	46
-āò̱	āò̱	aːɔ	101
-aͦ̄ò̱	aͦ̄ò̱	ɒːɔ	10
-aͤ̆ó	aͤ̆ó	æo	2
-a͜ō	a͜ō	aoː	2
-ă͜ʋ̆̀	ă͜ʋ̆̀	aʊ	1
-œʋ̱	œʋ̱	øu	1
-œ́u̱	œ́u̱	øy	19
-œͦ̆u̱	œͦ̆u̱	ɞy	10
-ȯœ̱́	ȯœ̱́	ɔø	2
-œ̆̀u̱	œ̆̀u̱	œy	24
-œͦ̆ʋ̱	œͦ̆ʋ̱	ɞu	28
-œ̆u̱	œ̆u̱	øy	4
-ŏ́ʋ̱	ŏ́ʋ̱	ou	69
-œ̀u̱	œ̀u̱	œy	53
-ā̀ó	ā̀ó	aːo	1
-à̱	à̱	a	31
-à̃	à̃	ã	98
-ãõ	ãõ	ãõ	2
-ḏẓ	ḏẓ	dz	6
-ṅ	ṅ	ŋ	9
-ā̀ó̱	ā̀ó̱	aːo	11
-é̃	é̃	ẽ	14
-é̃i̱	é̃i̱	ẽi	4
-ḗi̱	ḗi̱	eːi	22
-œ́ė̱̃	œ́ė̱̃	øə	2
-aé	aé	ae	8
-aͦ̆	aͦ̆	ɒ	28
-aͦ̄ë̱	aͦ̄ë̱	ɒːɛ	2
-āë̱	āë̱	aːɛ	3
-ae̱	ae̱	ae	1
-a̱͜è	a̱͜è	aɛ	11
-ė̩	ė̩	ə	141
-u̇	u̇	ʏ	47
-a̩	a̩	a	47
-ë̩	ë̩	ɛ	16
-ŭ̩̀	ŭ̩̀	ʏ	3
-oͮ̆	oͮ̆	o	33
-ʋ̩̇	ʋ̩̇	ʊ	3
-l̷	l̷	ʟ	54
-ȯ̱	ȯ̱	ɔ	190
-œ̩̆̀	œ̩̆̀	œ	19
-a̩ͦ̄	a̩ͦ̄	ɑː	6
-ē̩	ē̩	eː	6
-ā̀é	ā̀é	aːe	1
-ĕ̇	ĕ̇	e	2
-ā̩è̱	ā̩è̱	aːɛ	5
-ā̩́è̱	ā̩́è̱	ɑːɛ	3
-ă̩ì	ă̩ì	aɪ	1
-ằé̱	ằé̱	ae	3
-ė̱oͮ	ė̱oͮ	əo	1
-ʋ̄ė̱̃	ʋ̄ė̱̃	uːə	1
-èi̱	èi̱	ɛi	23
-a͜e	a͜e	ae	15
-ăĭ	ăĭ	aɪ	4
-ėi̱	ėi̱	əi	2
-ā́é̱	ā́é̱	ɑːe	2
-ẏ̱	ẏ̱	ʁ	1
-a͜ē	a͜ē	aeː	1
-ŏ̀i̱	ŏ̀i̱	ɔi	3
-ai	ai	ai	9
-ā͜è	ā͜è	aːɛ	6
-ằe̱	ằe̱	ae	2
-aĭ	aĭ	aɪ	1
-ḕ̩	ḕ̩	ɛː	24
-ò̱	ò̱	ɔ	338
-o̱	o̱	o	181
-ŏ̩̀i̱	ŏ̩̀i̱	ɔi	1
-ó̱	ó̱	o	5
-ḗ̩	ḗ̩	eː	14
-r̄	r̄	rː	43
-a̱ó	a̱ó	ao	10
-ò̱͜ó	ò̱͜ó	ɔo	8
-a̱͜e	a̱͜e	ae	7
-aó	aó	ao	24
-ā̩́	ā̩́	ɑː	9
-āó̱	āó̱	aːo	10
-òó̱	òó̱	ɔo	2
-ĕ̀é̱	ĕ̀é̱	ɛe	1
-ā́e̱	ā́e̱	ɑːe	1
-a͜ò	a͜ò	aɔ	60
-ă͜ŏ́	ă͜ŏ́	ao	2
-ȧʋ	ȧꭒ	ɐu	5
-óʋ	óꭒ	ou	5
-a̱ͦó	a̱ͦó	ɒo	1
-à͜ė	à͜ė	aə	1
-ằĭ	ằĭ	aɪ	1
-ằė̱	ằė̱	aə	1
-ī̩ė̱	ī̩ė̱	iːə	3
-īè̱	īè̱	iːɛ	183
-ēi̱	ēi̱	eːi	1
-ằ͜ĭ̀	ằ͜ĭ̀	aɪ	1
-ằi	ằi	ai	8
-g	g	g	606
-y̆̍	y̆̍	j	37
-ẓ̍	ẓ̍	ðˡ	16
-é̱	é̱	e	50
-d̮	d̮	dʲ	132
-a̱ṑ	a̱ṑ	aɔː	23
-oͮ̄	oͮ̄	oː	51
-èè̱	èè̱	ɛː	1
-a͜ó̱	a͜ó̱	ao	40
-aó̱	aó̱	ao	16
-ū̩̀	ū̩̀	ʏː	2
-ʋ̩̄	ʋ̩̄	uː	31
-ė̱ʋ̄̀	ė̱ʋ̄̀	əʊː	1
-a͜ò̱	a͜ò̱	aɔ	32
-ăŏ̀	ăŏ̀	aɔ	1
-ăoͮ	ăoͮ	ao	2
-è̃ė̱	è̃ė̱	ɛ̃ə	1
-è̃a̱	è̃a̱	ɛ̃a	1
-oͮ̄ʋ̱	oͮ̄ʋ̱	oːu	2
-ē̃	ē̃	ẽː	1
-ò͜ó	ò͜ó	ɔo	10
-ăó̃	ăó̃	aõ	2
-ʋ̩̄ė̱	ʋ̩̄ė̱	uːə	1
-oʋ	oꭒ	ou	8
-ṓʋ̱	ṓʋ̱	oːu	24
-a̱ó̩	a̱ó̩	ao	1
-ṓė̱	ṓė̱	oːə	20
-ʋ̄ė̱	ʋ̄ė̱	uːə	45
-ë̄	ë̄	ɛː	20
-œ̀i	œ̀i	œi	2
-ū̀	ū̀	ʏː	44
-ĕ́ă	ĕ́ă	ea	2
-ḗė̱	ḗė̱	eːə	14
-éė̱	éė̱	eə	1
-ù	ù	ʏ	21
-è̩	è̩	ɛ	44
-ū̩ė̱	ū̩ė̱	ʏə	1
-ė͜i	ė͜i	əi	1
-u̇ė̱	u̇ė̱	ʏə	1
-ŭ̩è̱	ŭ̩è̱	yɛ	1
-g̱	g̱	g	21
-è͋	è͋	ɛ	9
-ĭ̩t̮è	ĭ̩ t̮ è	i t e	1
-i̱ė	i̱ė	iə	1
-a̱è̃	a̱è̃	aɛ̃	42
-è̩̃	è̩̃	ɛ̃	26
-tç̵̑	tç̵̑	tɕ	31
-óï	óï	oɪ	1
-aͤ͜è̱	aͤ͜è̱	æɛ	1
-ắe̱	ắe̱	ɑe	1
-ăi̱	ăi̱	ai	2
-œ̩̄́	œ̩̄́	øː	7
-a̱è̄̃	a̱è̄̃	aɛ̃ː	11
-è̩̄̃	è̩̄̃	ɛ̃ː	7
-a͜a	a͜a	aː	1
-ā̃	ā̃	ãː	134
-ã̩	ã̩	ã	37
-è̩̃ĩ̱	è̩̃ĩ̱	ɛ̃i	10
-a̱aͤ̃	a̱aͤ̃	aæ̃	2
-l̄	l̄	lː	62
-ĕ̩	ĕ̩	e	18
-ė̩a	ė̩a	əa	1
-ëa	ëa	ɛa	1
-œ̀̃õ̱	œ̀̃õ̱	œ̃o	1
-ë̩o̱	ë̩o̱	ɛo	1
-ĭ̀	ĭ̀	ɪ	53
-œ̆̀͜oͮ	œ̆̀͜oͮ	œo	1
-ëi̱	ëi̱	ɛi	1
-œ̄u̱	œ̄u̱	øːy	8
-ooͮ̄	ooͮ̄	oː	1
-ẅ̑	ẅ̑	ɥ	27
-uͨ	uͨ	y	8
-ẽĩ̱	ẽĩ̱	ẽi	23
-ā̀é̱	ā̀é̱	aːe	9
-ò̄̃	ò̄̃	ɔ̃ː	24
-sãtc̵̾ç̑é	s ã tc̵̾ç̑ é	s ã tʃ ɛ	1
-è̱ã	è̱ã	ɛã	11
-è̩i	è̩i	ɛi	1
-ī̩a	ī̩a	iːa	16
-a̩͜è	a̩͜è	aɛ	2
-ă͜eͥ	ă͜eͥ	ae	1
-r̥	r̥	r	14
-ie̱	ie̱	ie	2
-ài̱	ài̱	ai	1
-dy̓	dy̓	dʒʲ	13
-i̩a	i̩a	ɪa	30
-a͜è̱	a͜è̱	aɛ	11
-i̩ȯ̱	i̩ȯ̱	ɪɔ	2
-é̩i	é̩i	ei	1
-ăe̱ͥ	ăe̱ͥ	ae	1
-ʋė̱	ꭒė̱	uə	9
-s̄	s̄	sː	1
-eaͤ̆	eaͤ̆	eæ	1
-ĕ̀ĕ̀	ĕ̀ĕ̀	ɛː	1
-è͜è	è͜è	ɛː	3
-ăĕ̀	ăĕ̀	aɛ	4
-ă͜ó	ă͜ó	ao	6
-ā́ò̱	ā́ò̱	ɑːɔ	20
-ă͜ó̱	ă͜ó̱	ao	12
-ŏ̀͜ó̱	ŏ̀͜ó̱	ɔo	2
-ă͜e̱	ă͜e̱	ae	3
-a͜e̱	a͜e̱	ae	5
-èé̱	èé̱	ɛe	2
-a̱͜ḕ	a̱͜ḕ	aɛː	8
-ʋ̩	ʋ̩	u	6
-a͜oͮ	a͜oͮ	ao	6
-o̱ͮ	o̱ͮ	o	8
-ėò̃	ėò̃	əɔ̃	2
-uͨu̱	uͨu̱	yː	2
-a̱ò̃	a̱ò̃	aɔ̃	24
-u͜ằ	u͜ằ	ya	1
-yʋ͜ă	y ʋ͜ă	j ua	1
-o͜ă	o͜ă	oa	2
-ūė̱	ūė̱	yːə	96
-ă͜oͮ	ă͜oͮ	ao	2
-a̱aͦ̄	a̱aͦ̄	aɒː	3
-a̩ͤ͜ŏ́	a̩ͤ͜ŏ́	æo	2
-œ̄œ̱́	œ̄œ̱́	øːø	1
-œ̆̀ʋ̱ͧ	œ̆̀ʋ̱ͧ	œʉ	10
-ãò̱̃	ãò̱̃	ãɔ	5
-ãó̱̃	ãó̱̃	ão	14
-œ̆͜ò̃	œ̆͜ò̃	øɔ̃	1
-ūa	ūa	ỹːa	5
-ė̱i	ė̱i	əi	1
-īa̱	īa̱	iːa	22
-īa	īa	iːa	7
-ẅ̱	ẅ̱	ɥ	14
-ŭ̀a	ŭ̀a	ʏa	1
-ĭ̩	ĭ̩	i	22
-ă͜ḕ̩	ă͜ḕ̩	aɛː	1
-a͜é̩	a͜é̩	ae	1
-à͜è̱	à͜è̱	aɛ	1
-a͜i	a͜i	ai	3
-ăi	ăi	ai	6
-ĕ̀i	ĕ̀i	ɛi	8
-ĕ́͜i̱	ĕ́͜i̱	ei	1
-a̱͜é	a̱͜é	ae	3
-aͤ͜è	aͤ͜è	æɛ	1
-ā́è	ā́è	ɑːɛ	5
-ae̱ͥ	ae̱ͥ	ae	2
-œ͜u̱	œ͜u̱	øy	2
-œ̄̀œ̱́	œ̄̀œ̱́	œːø	1
-tc̵̾	tc̵̾	tʃ	61
-ò͜ă	ò͜ă	ɔa	1
-œ̆́u̱	œ̆́u̱	øy	3
-ì	ì	ɪ	35
-œ̆̀ā	œ̆̀ā	œaː	2
-ëā	ëā	ɛaː	1
-œ̆̀o	œ̆̀o	œo	1
-ā͜ò̱	ā͜ò̱	aːɔ	1
-ŏ̀ʋ̱	ŏ̀ʋ̱	ɔu	2
-è̃ĩ	è̃ĩ	ɛ̃ɪ̃	14
-ăè̃	ăè̃	aɛ̃	1
-m̱	m̱	m	21
-ya͜é̱	y a͜é̱	j ae	1
-ă͜é̱	ă͜é̱	ae	5
-ãè̱̃	ãè̱̃	ãɛ	5
-ĩ̱	ĩ̱	ɪ̃	35
-ā̩̃	ā̩̃	ãː	7
-aͤ̃ĩ̱	aͤ̃ĩ̱	æ̃i	4
-d̯	d̯	d	19
-ò̩ʋ̱	ò̩ʋ̱	ɔu	1
-ŏ̱	ŏ̱	o	2
-ò͜ó̱	ò͜ó̱	ɔo	13
-œ̆̀͜ò̃	œ̆̀͜ò̃	œɔ̃	1
-á̱	á̱	ɑ	6
-ḕė̱	ḕė̱	ɛːə	1
-è̱͜é	è̱͜é	ɛe	2
-aͤ̄e̱	aͤ̄e̱	æːe	1
-ḗă	ḗă	eːa	8
-uͨù̱	uͨù̱	yʏ	1
-ā̩́ò̱	ā̩́ò̱	ɑːɔ	1
-a̱ͤ͜ó	a̱ͤ͜ó	æo	3
-a̩͜ó	a̩͜ó	ao	4
-œ̀ʋ̱ͧ	œ̀ʋ̱ͧ	œʉ	20
-ūo̱	ūo̱	ỹːo	2
-o̱ā	o̱ā	oaː	2
-ʋ̱ͧ	ʋ̱ͧ	ʉ	1
-ã̱	ã̱	ã	10
-ũ	ũ	ỹ	8
-ʋ̀	ʋ̀	ʊ	17
-uė̱	uė̱	yə	3
-è̄̃ĩ̱	è̄̃ĩ̱	ɛ̃ːi	9
-i̩a̩	i̩a̩	ɪa	3
-ī̩ò̱	ī̩ò̱	iːɔ	3
-a̩ͤ̆	a̩ͤ̆	æ	6
-œͦ̄	œͦ̄	ɞː	2
-t̯	t̯	t	6
-tʋ͜è	t ʋ͜è	t ue	1
-ă̩è̱	ă̩è̱	aɛ	1
-āï̱	āï̱	aːɪ	1
-īò̱	īò̱	iːɔ	5
-ë̩̆	ë̩̆	ɛ	2
-ī̩e̱	ī̩e̱	iːe	1
-ī̩a̱	ī̩a̱	iːa	7
-l̮̱	l̮̱	ʎ	46
-ëė̱	ëė̱	ɛə	1
-aͦè̱	aͦè̱	ɒɛ	5
-œ͜ù	œ͜ù	øʏ	1
-a̩ͤ͜ó	a̩ͤ͜ó	æo	4
-ōœ̱̀	ōœ̱̀	oːœ	1
-e̱i	e̱i	ei	1
-ṓ̩	ṓ̩	oː	23
-ā͜è̱	ā͜è̱	aːɛ	2
-ṑ̩r	ṑ̩ r	o r	10
-n̯	n̯	n	2
-ʋ̄ȯ̱	ʋ̄ȯ̱	uːɔ	11
-eͥi̱	eͥi̱	ei	7
-ḗa̱	ḗa̱	eːa	1
-èo	èo	ɛo	1
-l̯	l̯	l	4
-ç̵̑	ç̵̑	ɕ	7
-e̩ͥ	e̩ͥ	e	3
-ė̱é	ė̱é	əe	4
-ĕ̩́i̱	ĕ̩́i̱	ei	2
-a̱ͦ	a̱ͦ	ɒ	10
-ă̱͜ĕ̀	ă̱͜ĕ̀	aɛ	1
-ao̱	ao̱	ao	2
-ă̩͜è	ă̩͜è	aɛ	1
-ăe̱	ăe̱	ae	1
-ò̱ó	ò̱ó	ɔo	10
-aʋ̀	aʋ̀	aʊ	2
-ṓò̱	ṓò̱	oːɔ	1
-ʋ̄è̱	ʋ̄è̱	uːɛ	8
-e̩ͥ̄i̱	e̩ͥ̄i̱	ei	1
-eͥ̄	eͥ̄	eː	22
-ė̱é̩	ė̱é̩	əe	1
-ằ̱	ằ̱	a	1
-ă̱	ă̱	a	1
-œ̀u	œ̀u	œy	9
-aò	aò	aɔ	19
-ă̩ḗ	ă̩ḗ	aeː	1
-ăó̱	ăó̱	ao	7
-a̩ͦ	a̩ͦ	ɑ	2
-œ̩̆	œ̩̆	ø	2
-ă̩ó̱	ă̩ó̱	ao	4
-œ̩̀ṓ	œ̩̀ṓ	œoː	1
-ŏ̀œ̱́	ŏ̀œ̱́	ɔø	1
-a̩͜ṑ	a̩͜ṑ	aɔː	1
-ʋ̩̄̀	ʋ̩̄̀	u	2
-ūè̱	ūè̱	ỹːɛ	8
-œœ̱́	œœ̱́	øː	1
-ĕã	ĕã	eã	1
-ëã	ëã	ɛã	1
-ĕ̀ã	ĕ̀ã	ɛã	2
-o̩ͮă	o̩ͮă	oa	1
-è̱à̃	è̱à̃	ɛã	3
-aͤ͋	aͤ͋	æ	3
-ã̱ò̃	ã̱ò̃	ãɔ̃	19
-ãó̃	ãó̃	ãõ	1
-ŭ̀	ŭ̀	ʏ	50
-ȧ	ȧ	ɐ	20
-ḻ	ḻ	l	10
-œ́ʋ̱	œ́ʋ̱	øu	1
-c̑	c̑	x	5
-œ̱̀	œ̱̀	œ	1
-ȯ̩	ȯ̩	ɔ	4
-aʋ̱̀	aʋ̱̀	aʊ	1
-ū̩a̱	ū̩a̱	ʏa	1
-ʋ̩̄a̱	ʋ̩̄a̱	uːa	5
-ằ̩	ằ̩	a	11
-ʋ̩a	ʋ̩a	ua	3
-oă̩	oă̩	oa	1
-u͜a̩	u͜a̩	ya	1
-ʋ̄a̱	ʋ̄a̱	uːa	21
-e̩	e̩	e	3
-j̱	j̱	ʒ	2
-œ̱̀͜ŏ́	œ̱̀͜ŏ́	œo	3
-ĕ́ė̱	ĕ́ė̱	eə	1
-ḕé̱	ḕé̱	ɛːe	9
-ȧu̱	ȧu̱	ɐy	1
-i͜ằ	i͜ằ	ia	1
-a̱͜ó	a̱͜ó	ao	7
-eͥ̆	eͥ̆	e	36
-i͜ë	i͜ë	iɛ	1
-ò̩̃	ò̩̃	ɔ̃	15
-āa	āa	aːa	1
-āa̱	āa̱	aːa	2
-āo̱	āo̱	aːo	3
-a̱͜ṑ	a̱͜ṑ	aɔː	4
-ōė̱	ōė̱	oːə	3
-ë̱͜ó	ë̱͜ó	ɛo	1
-ŏ̀͜œ̱́	ŏ̀͜œ̱́	ɔø	1
-œ̩u̱	œ̩u̱	øy	1
-i͜ĕ	i͜ĕ	ie	1
-œ̀oͮ	œ̀oͮ	œo	2
-œ̆̀œ̱́	œ̆̀œ̱́	œø	2
-a͜o̱	a͜o̱	ao	2
-ò̱͜oͮ	ò̱͜oͮ	ɔo	1
-ŏ́a	ŏ́a	oa	1
-ĕ̀ī	ĕ̀ī	ɛiː	3
-aĕ̀	aĕ̀	aɛ	1
-ŏ̩	ŏ̩	o	19
-œ̀͜u	œ̀͜u	œy	1
-aͤ̆͜ŏ́	aͤ̆͜ŏ́	æo	1
-a͜ḕ	a͜ḕ	aɛː	1
-œ̱̀͜i	œ̱̀͜i	œi	2
-a͜ʋ̱	a͜ʋ̱	au	1
-ā̩̀	ā̩̀	aː	3
-u̩	u̩	y	9
-ū̩	ū̩	ʏ	11
-u͜à̱	u͜à̱	ya	1
-u͜a	u͜a	ya	1
-ūë̱	ūë̱	ỹːɛ	4
-ʋ̩̆i̱	ʋ̩̆i̱	ui	1
-oͮ̄è̱	oͮ̄è̱	oːɛ	2
-oͮe̱ͥ	oͮe̱ͥ	oe	1
-a̩ͤ	a̩ͤ	æ	1
-ʋ̄é	ʋ̄é	uːe	1
-ŭ͜è	ŭ͜è	yɛ	1
-uė	uė	yə	1
-i̩ė̱	i̩ė̱	ɪə	2
-ŭ̩	ŭ̩	y	735
-ēé̱	ēé̱	eːe	2
-ăʋ̆̀	ăʋ̆̀	aʊ	1
-ò̱œ̄	ò̱œ̄	ɔøː	8
-œ̀œ̱́	œ̀œ̱́	œø	1
-ȯu̱	ȯu̱	ɔy	1
-o̱ʋ	o̱ꭒ	ou	1
-s̱	s̱	s	4
-ī̀ė̱	ī̀ė̱	ɪːə	4
-ōa	ōa	oːa	1
-óo̱	óo̱	oː	1
-ė̩é̱	ė̩é̱	əe	1
-a̱ͦ͜ṑ	a̱ͦ͜ṑ	ɒɔː	1
-œ̀o̱ͮ	œ̀o̱ͮ	œo	5
-ì̩	ì̩	ɪ	3
-ō̩	ō̩	o	6
-ŏ̩́ă	ŏ̩́ă	oa	1
-ă̩ŏ́	ă̩ŏ́	ao	5
-yœ̩͜u̱	y œ̩͜u̱	j øy	1
-aͤ͜oͮ	aͤ͜oͮ	æo	1
-ya͜ò	y a͜ò	j aɔ	1
-ya͜ó	y a͜ó	j ao	1
-œ̄́u̱	œ̄́u̱	øːy	1
-yă͜é̱	y ă͜é̱	j ae	1
-œ̆ŭ̀	œ̆ŭ̀	øʏ	1
-o̱œ̄	o̱œ̄	oøː	1
-a̩͜ò	a̩͜ò	aɔ	2
-a͜ṓ	a͜ṓ	aoː	3
-ʋͧ̄a	ʋͧ̄a	ʉːa	2
-ʋo̱	ꭒo̱	uo	1
-ï̩	ï̩	ɪ	1
-ā̩ò̱	ā̩ò̱	aːɔ	6
-ṑ̩	ṑ̩	ɔː	4
-ò̩	ò̩	ɔ	16
-é̩	é̩	e	2
-ẽ̱	ẽ̱	e	1
-z̾	z̾	z̥	3
-ãẽ	ãẽ	ãẽ	15
-jͨ	jͨ	ʒ	4
-œ̱̀͜ó	œ̱̀͜ó	œo	12
-ăò̃	ăò̃	aɔ̃	1
-è̩̄̃ĩ̱	è̩̄̃ĩ̱	ɛ̃ːi	2
-è̩̃i̱	è̩̃i̱	ɛ̃i	1
-œ̩̀	œ̩̀	œ	1
-œ̩̀̃	œ̩̀̃	ø	1
-ė̱̃	ė̱̃	ə̃	1
-ăḕ	ăḕ	aɛː	1
-ā̩é̱	ā̩é̱	aːe	1
-ă̩ḕ	ă̩ḕ	aɛː	1
-a̩ͤi̱	a̩ͤi̱	æi	1
-ī̀o	ī̀o	ɪːo	1
-a̱ē	a̱ē	aeː	2
-ṓó̱	ṓó̱	oːo	1
-là̃	l à̃	l ã	7
-o̱ã	o̱ã	oã	1
-ḗé̱	ḗé̱	eːe	1
-ūė	ūė	ỹːə	5
-œ̱́ŭ̀	œ̱́ŭ̀	øʏ	1
-u͜ė	u͜ė	yə	1
-o̱è̃	o̱è̃	oɛ̃	2
-œ̱̀͜ṓ	œ̱̀͜ṓ	œoː	2
-ė̱͜ó	ė̱͜ó	əo	1
-œ̱̀͜ó̩	œ̱̀͜ó̩	œo	1
-ʋ̱̇	ʋ̱̇	ʊ	5
-a̱͜ò	a̱͜ò	aɔ	5
-ă͜oͮ̆	ă͜oͮ̆	ao	1
-yā͜ò̱	y ā͜ò̱	j aːɔ	1
-œ̩̄̀	œ̩̄̀	ø	2
-a̱ͤó̩	a̱ͤó̩	æo	1
-ò̱͜œ	ò̱͜œ	ɔø	1
-ʋ̩ͧ	ʋ̩ͧ	ʉ	2
-u̩̇	u̩̇	ʏ	1
-ȯ̱ʋ	ȯ̱ꭒ	ɔu	1
-ʋͧ̆	ʋͧ̆	ʉ	14
-œ̄́ŭ̩	œ̄́ŭ̩	øːy	1
-ă͜ĕ̀	ă͜ĕ̀	aɛ	1
-ā͜é̱	ā͜é̱	aːe	2
-ĕ̩́	ĕ̩́	e	3
-ò͜è	ò͜è	ɔɛ	2
-ŏ̀i	ŏ̀i	ɔi	6
-è͋ĩ̱	è͋ĩ̱	ɛi	1
-é͋	é͋	e	1
-ḗi	ḗi	eːi	2
-óă	óă	oa	1
-w̄	w̄	wː	2
-^na̱ṑ̩va̱	n a̱ṑ̩ v a̱	n aoː v a	2
-aͤ͜ó	aͤ͜ó	æo	10
-ȯ̱͜œ	ȯ̱͜œ	ɔø	1
-œ̄̀u̱	œ̄̀u̱	œːy	7
-œͦu̱	œͦu̱	ɞy	3
-œͦ̄o̱ͮ	œͦ̄o̱ͮ	ɞːo	1
-ʋ̃a̱	ʋ̃a̱	ũa	1
-ūa̱	ūa̱	ỹːa	5
-œͧ̄	œͧ̄	øː	1
-yà	y à	j a	1
-ï̩̄	ï̩̄	ɪː	1
-i̩ò̩̃	i̩ò̩̃	ɪɔ̃	2
-œ̱̀ò̄̃	œ̱̀ò̄̃	œɔ̃ː	1
-ū̩a	ū̩a	ʏa	4
-ʋ̩a̱	ʋ̩a̱	ua	2
-ù̩	ù̩	ʏ	2
-ū̀a̱	ū̀a̱	ʏːa	4
-a̱ͤŏ́	a̱ͤŏ́	æo	2
-ʋ͜ă	ʋ͜ă	ua	1
-œͦ̆ʋͧ	œͦ̆ʋͧ	ɞʉ	1
-ʋͧ̄a̱	ʋͧ̄a̱	ʉːa	1
-ʋ̄a	ʋ̄a	uːa	1
-u̩a	u̩a	ya	2
-i̩a̱	i̩a̱	ɪa	4
-iò̩̃	iò̩̃	iɔ̃	1
-ȧ̱	ȧ̱	ɐ	25
-ó̩ʋ̱	ó̩ʋ̱	ou	1
-o̩ʋ	o̩ꭒ	ou	1
-ã̱é̃	ã̱é̃	aẽ	7
-iŏ	iŏ	io	1
-ȱ	ȱ	ɔː	2
-œ̱ò̩̃	œ̱ò̩̃	øɔ̃	1
-aʋ	aꭒ	au	6
-ă͜i̱	ă͜i̱	ai	1
-œ̱͜ó	œ̱͜ó	øo	3
-ŏ̀ĕ̀	ŏ̀ĕ̀	ɔɛ	1
-òă	òă	ɔa	1
-œ̄́ʋ̱	œ̄́ʋ̱	øːu	1
-œ̱ū̀	œ̱ū̀	øʏː	2
-a̩ó	a̩ó	ao	2
-ăò	ăò	aɔ	2
-œͦʋ̱ͧ	œͦʋ̱ͧ	ɞʉ	1
-ʋͧ̄	ʋͧ̄	ʉː	11
-œͧ	œͧ	ø	1
-ṑ͜ó̱	ṑ͜ó̱	ɔːo	1
-ḗ̩ă	ḗ̩ă	eːa	1
-ʋ̆ė̱̃	ʋ̆ė̱̃	uə	1
-ḕò	ḕò	ɛːɔ	1
-ā̩ò	ā̩ò	aːɔ	1
-a͜ā	a͜ā	aː	1
-oͮā	oͮā	oaː	1
-ʋ̩̄a	ʋ̩̄a	uːa	2
-ʋͧ͜a	ʋͧ͜a	ua	1
-ȧ̩	ȧ̩	ɐ	1
-ʋ̄ò̱	ʋ̄ò̱	uːɔ	3
-ʋ̄ė	ʋ̄ė	uːə	1
-u͜ĕ̀	u͜ĕ̀	yɛ	1
-ʋ̄ë̱	ʋ̄ë̱	uːɛ	6
-r̍	r̍	rˡ	16
-ó͜ă	ó͜ă	oa	1
-œ̱̀͜oͮ	œ̱̀͜oͮ	œo	1
-òʋ̱	òʋ̱	ɔu	8
-œ̱̀oͮ̄	œ̱̀oͮ̄	œoː	1
-ʋ̩̆a̱ͦ̃	ʋ̩̆a̱ͦ̃	uɒ	1
-ḕa̱	ḕa̱	ɛːa	2
-oḕ	oḕ	oɛː	1
-éă	éă	ea	1
-ao	ao	ao	3
-œ̩̆u̱	œ̩̆u̱	øy	1
-a̱ͤoͮ	a̱ͤoͮ	æo	1
-ò̱͜œ̄̀	ò̱͜œ̄̀	ɔœː	3
-œͦ̆o̱ͮ	œͦ̆o̱ͮ	ɞo	3
-œ̆̀o̱ͮ	œ̆̀o̱ͮ	œo	1
-ò͜ʋ	ò͜ꭒ	ɔu	1
-uͨ̄	uͨ̄	yː	3
-ŏ̀ó̱	ŏ̀ó̱	ɔo	2
-a̱ͤĩ	a̱ͤĩ	æɪ̃	1
-aḕ	aḕ	aɛː	1
-aó̃	aó̃	aõ	2
-a͜i̱	a͜i̱	ai	4
-d̯̄	d̯̄	dː	1
-l̷̄	l̷̄	ʟː	2
-õ̱	õ̱	õ	1
-œ̱̀ʋ̆̀	œ̱̀ʋ̆̀	œʊ	1
-ʋ̄́	ʋ̄́	u	1
-dͭ	dͭ	d̥	12
-áè̱	áè̱	ɑɛ	2
-eͥ̆ă	eͥ̆ă	ea	1
-ēė̱	ēė̱	eːə	4
-ãĩ̱	ãĩ̱	ãi	1
-a̱è̩̃	a̱è̩̃	aɛ̃	2
-ằè͋	ằè͋	aɛ	1
-ĕ̇i̱	ĕ̇i̱	ei	1
-ā̩é̩	ā̩é̩	aːe	1
-ăa̩ͤ̆	ăa̩ͤ̆	aæ	1
-ăī	ăī	aiː	1
-ăĭ̩	ăĭ̩	aɪ	1
-ãẽ̱	ãẽ̱	ãe	4
-ë̃	ë̃	ɛ	3
-ù̃ė̱	ù̃ė̱	ỹə	1
-ắ̩	ắ̩	ɑ	4
-ï̩̆	ï̩̆	ɪ	1
-ă̩̇	ă̩̇	ɐ	1
-īȧ̱	īȧ̱	iːɐ	1
-œ̱̀ʋ̄̀	œ̱̀ʋ̄̀	œʊː	1
-ăo̱	ăo̱	ao	2
-a̱͜òyè̱	a̱͜ò y è̱	aɔ j ɛ	2
-eͥ̆i	eͥ̆i	ei	1
-a̱͜òy	a̱͜ò y	aɔ j	1
-œ̱̀ò̃	œ̱̀ò̃	œɔ̃	9
-ì̩è̱	ì̩è̱	ɪɛ	1
-ĕ̱̀	ĕ̱̀	ɛ	3
-ʋ̱̩̀	ʋ̱̩̀	u	1
-ȧ̱è̄̃	ȧ̱è̄̃	ɐɛ̃ː	1
-c̵͜	c̵͜	ʃ	1
-a̱̩è̃	a̱̩è̃	aɛ̃	1
-s͜	s͜	s	1
-aͦ̃ė̃	aͦ̃ė̃	ɑə̃	1
-àī̩	àī̩	aiː	1
-oͮ̃	oͮ̃	õ	16
-eͥ̃	eͥ̃	ẽ	9
-i̩a̱ͦ	i̩a̱ͦ	ɪɒ	1
-i̩ă̩	i̩ă̩	ɪa	1
-ī̀è̱	ī̀è̱	ɪːɛ	4
-œù̱	œù̱	øʏ	1
-a̱ͤó	a̱ͤó	æo	1
-ò̱͜œ̄	ò̱͜œ̄	ɔøː	2
-ȧ̩ʋ	ȧ̩ꭒ	ɐu	1
-ʋ̄a̱ͦ	ʋ̄a̱ͦ	uːɒ	1
-ʋ̩̄a̩	ʋ̩̄a̩	uːa	1
-ʋ̩̄ă̩	ʋ̩̄ă̩	uːa	1
-ḕè̱	ḕè̱	ɛːɛ	1
-ŭ̀a̱	ŭ̀a̱	ʏa	1
-ū̀ȧ̱	ū̀ȧ̱	ʏːɐ	1
-ʋ͜ắ	ʋ͜ắ	ua	1
-oͮ͜a	oͮ͜a	oa	1
-ʋ̄ȧ̱	ʋ̄ȧ̱	uːɐ	1
-ēë̱	ēë̱	eːɛ	1
-ăè	ăè	aɛ	1
-aė̱	aė̱	aə	1
-t̮̄	t̮̄	tʲ	2
-iȯ̱	iȯ̱	iɔ	1
-a̱è	a̱è	aɛ	3
-ŏ̩́	ŏ̩́	o	2
-ṉ̇͜	ṉ̇͜	ŋ	1
-ãò̃	ãò̃	ãɔ̃	3
-aͦ̃͜é̃	aͦ̃͜é̃	ɑẽ	2
-īa̱ͦ	īa̱ͦ	iːɒ	1
-uè	uè	yɛ	2
-ă͜ĕ́	ă͜ĕ́	ae	1
-ūè	ūè	ỹːɛ	3
-uĕ̀	uĕ̀	yɛ	1
-ū̀è̱	ū̀è̱	ʏːɛ	1
-i͋	i͋	i	1
-ʋ̩̆è̩	ʋ̩̆è̩	uɛ	1
-i̩è̱	i̩è̱	ɪɛ	2
-a͜ʋ	a͜ꭒ	au	1
-u̩è	u̩è	yɛ	1
-èĩ̱	èĩ̱	ɛi	1
-ṓë̱	ṓë̱	oːɛ	2
-ʋ̆͜	ʋ̆͜	u	4
-ʋ̆ă	ʋ̆ă	ua	1
-óè	óè	oɛ	1
-ʋë̱	ꭒë̱	uɛ	1
-ʋȯ̱	ꭒȯ̱	uɔ	1
-i̩è	i̩è	ɪɛ	1
-ì̩a	ì̩a	ɪa	1
-ė͋	ė͋	e	1
-a̱͜aͤ̄	a̱͜aͤ̄	aæː	1
-ā͜é	ā͜é	aːe	1
-ăĕ́	ăĕ́	ae	1
-ia	ia	ia	1
-o͜ĭ	o͜ĭ	oɪ	1
-a̱ͦ̃è̃	a̱ͦ̃è̃	ɒɛ̃	2
-īë	īë	iːɛ	1
-iè̱	iè̱	iɛ	3
-ă̩ó	ă̩ó	ao	1
-ŏ̩̀ĭ	ŏ̩̀ĭ	ɔɪ	3
-t̄	t̄	tː	4
-ẽ̩ĩ̱	ẽ̩ĩ̱	ei	2
-è̩i̱	è̩i̱	ɛi	1
-a̱ͤè̃	a̱ͤè̃	æɛ̃	1
-ằĕ̀	ằĕ̀	aɛ	1
-ẽi̱	ẽi̱	ẽi	1
-œ́̃	œ́̃	ø̃	1
-oͮ̄o̱ͮ	oͮ̄o̱ͮ	oːo	2
-ʋ̄̀ė̱	ʋ̄̀ė̱	ʊːə	3
-ū̀ė̱	ū̀ė̱	ʏːə	1
-œ̱̀i	œ̱̀i	œi	2
-ʋ͜	ʋ͜	u	7
-ă̩oͮ	ă̩oͮ	ao	2
-ṟ̇	ṟ̇	ʀ	2
-oʋ̱̆	oʋ̱̆	ou	1
-a̱̩ͤ͜ó	a̱̩ͤ͜ó	æo	2
-ò̱̩œ̄	ò̱̩œ̄	ɔøː	2
-a̱͜ō	a̱͜ō	aoː	1
-m̄	m̄	mː	9
-õ̩	õ̩	o	1
-a̩ͦ̃	a̩ͦ̃	ɑ	2
-ă̩ò̱	ă̩ò̱	aɔ	1
-a̩ò	a̩ò	aɔ	1
-a̩ͦ̄ò̱	a̩ͦ̄ò̱	ɑːɔ	1
-a̩ò̱	a̩ò̱	aɔ	1
-œ̆̀u	œ̆̀u	œy	3
-ò̱œ̄̀	ò̱œ̄̀	ɔœː	4
-á̩	á̩	ɑ	1
-aͤó	aͤó	æo	4
-a̱ͤ	a̱ͤ	æ	2
-l̮à̃	l̮ à̃	l ã	8
-yà̃	y à̃	j ã	6
-ò̱̃	ò̱̃	ɔ̃	2
-œ̱ó	œ̱ó	øo	2
-a̱ͦ͜è̃	a̱ͦ͜è̃	ɒɛ̃	1
-ăoͮ̆	ăoͮ̆	ao	2
-ăyă͜ó̱	ă y ă͜ó̱	a j ao	2
-a̱é̃	a̱é̃	aẽ	1
-ãè̃	ãè̃	ãɛ̃	2
-ăā	ăā	aː	1
-a̱ͦ̃é̃	a̱ͦ̃é̃	ɒẽ	1
-ẕ	ẕ	z	1
-ië̱	ië̱	iɛ	4
-a̱͜è̃	a̱͜è̃	aɛ̃	2
-ã̱ẽ	ã̱ẽ	aẽ	2
-œ̆̀ṓ	œ̆̀ṓ	œoː	1
-a͜e̱ͥ	a͜e̱ͥ	ae	1
-ȯ̱ʋ̃	ȯ̱ʋ̃	ɔũ	1
-œ̄́ù̱	œ̄́ù̱	øːʏ	1
-aͤ̄oͮ	aͤ̄oͮ	æːo	1
-ṑœ̱̀	ṑœ̱̀	ɔːœ	1
-uͨœ	uͨœ	yø	1
-u̱̇	u̱̇	ʏ	8
-ã̱ò̱̃	ã̱ò̱̃	aɔ	1
-è̱̩	è̱̩	e	2
-œ̱̀ó	œ̱̀ó	œo	2
-aè̃	aè̃	aɛ̃	1
-ĭ̱	ĭ̱	i	1
-œ̀͜i	œ̀͜i	œi	1
-o̩ͮ	o̩ͮ	o	2
-c̵̯	c̵̯	ʃ	2
-ḕa	ḕa	ɛːa	3
-œ̆̀o̱	œ̆̀o̱	œo	1
-œ̱̀ū̀	œ̱̀ū̀	œʏː	1
-ȯ̱͜œ̩̄	ȯ̱͜œ̩̄	ɔøː	1
-œ̩	œ̩	ø	1
-ūò̃	ūò̃	ỹːɔ̃	1
-ă̩ĭ	ă̩ĭ	aɪ	1
-ăeͥ	ăeͥ	ae	1
-āĕ	āĕ	aːe	1
-ẓ̱	ẓ̱	ð	3
-ė̱ã	ė̱ã	əã	1
-aͦ̃͜è̃	aͦ̃͜è̃	ɑɛ̃	4
-aͤ̄è̱̃	aͤ̄è̱̃	æːɛ	2
-i͜ė	i͜ė	iə	1
-a̱͜aͤ	a̱͜aͤ	aæ	1
-āò	āò	aːɔ	3
-ò̱͜eͥ̆	ò̱͜eͥ̆	ɔe	1
-aò̃	aò̃	aɔ̃	1
-ãé̱̃	ãé̱̃	ãe	1
-è̱͜ã	è̱͜ã	ɛã	1
-œ̱̀͜ò̃	œ̱̀͜ò̃	œɔ̃	1
-ăʋ̆	ăʋ̆	au	2
-āo̱͜è	āo̱͜ è	aːo ɛ	1
-è͜i̱	è͜i̱	ɛi	1
-ăe	ăe	ae	1
-è̱ē	è̱ē	ɛeː	1
-ŏ̀ĭ	ŏ̀ĭ	ɔɪ	3
-aó̱̃	aó̱̃	ao	1
-ā̩o̱	ā̩o̱	aːo	1
-aõ̱	aõ̱	ao	1
-āò̃	āò̃	aːɔ̃	2
-ȯ̱̃	ȯ̱̃	ɔ	1
-aͦò̱	aͦò̱	ɒɔ	1
-ʋ̀̃ė̱̃	ʋ̀̃ė̱̃	ʊ̃ə	3
-à̄̃	à̄̃	ãː	1
-œ́ù̱	œ́ù̱	øʏ	1
-œ͜ó	œ͜ó	øo	1
-œ̀͜ó	œ̀͜ó	œo	3
-ė̱ṑ	ė̱ṑ	əɔː	1
-œͦ	œͦ	ɞ	2
-aͦ̄ʋ̱	aͦ̄ʋ̱	ɒːu	1
-ăò̱	ăò̱	aɔ	2
-a̩ͦè̱	a̩ͦè̱	ɑɛ	1
-ie	ie	ie	1
-ĕī	ĕī	eiː	1
-ĕ̀ḗ	ĕ̀ḗ	ɛeː	2
-ĕ̀ē	ĕ̀ē	ɛeː	1
-ĕḗ	ĕḗ	eː	1
-a̩͜é	a̩͜é	ae	1
-oͮ̄ė̱	oͮ̄ė̱	oːə	1
-ṓè̱	ṓè̱	oːɛ	1
-ĭ̩̀	ĭ̩̀	ɪ	1
-ắo	ắo	ɑo	1
-œ̩̀u̱	œ̩̀u̱	œy	1
-é͜i̱	é͜i̱	ei	1
-ŏ̀ë	ŏ̀ë	ɔɛ	1
-ŏĕ̀	ŏĕ̀	oɛ	1
-i̩ṑ	i̩ṑ	ɪɔː	1
-ia͜ó̱	i a͜ó̱	i ao	1
-yò͜ó̱	y ò͜ó̱	j ɔo	1
-ʋ̆ò	ʋ̆ò	uɔ	1
-œu	œu	øy	3
-ȯ̱ʋ̄̀	ȯ̱ʋ̄̀	ɔʊː	1
-œ̱̀ṑ	œ̱̀ṑ	œɔː	1
-ĕ́ë̱	ĕ́ë̱	eɛ	1
-^dj͛yŏ̀	dj͛ y ŏ̀	dʒ j ɔ	1
-i̩ò	i̩ò	ɪɔ	1
-ăʋ̱̀	ăʋ̱̀	aʊ	2
-ʋ̆ė̱	ʋ̆ė̱	uə	1
-ŏʋ̱	ŏʋ̱	ou	4
-a̩ṓ	a̩ṓ	aoː	1
-ʋè̩	ꭒè̩	uɛ	1
-aͤ͜ó̩	aͤ͜ó̩	æo	1
-ò̱œ̩̄	ò̱œ̩̄	ɔøː	1
-aͤì̱	aͤì̱	æɪ	1
-ʋ̀̃ė̱	ʋ̀̃ė̱	ʊ̃ə	1
-œͧu̱	œͧu̱	øy	1
-ūœ̱́	ūœ̱́	ỹːø	1
-è̱ā̩̃	è̱ā̩̃	ɛãː	1
-à̩̃	à̩̃	ã	2
-ë̆	ë̆	ɛ	1
-œ̱̀͜ṓ̩	œ̱̀͜ṓ̩	œoː	1
-ã̱͜è̃	ã̱͜è̃	aɛ̃	2
-u͜ā̩	u͜ā̩	yaː	1
-ʋ̆ó	ʋ̆ó	uo	1
-ʋ̆ā	ʋ̆ā	uaː	3
-ò͜ā	ò͜ā	ɔaː	1
-ŏ̀ŏ́	ŏ̀ŏ́	ɔo	1
-u͜āyė̱	u͜ā y ė̱	yaː j ə	1
-ò͜āè	ò͜ā è	ɔaː ɛ	1
-ò͜āè̱	ò͜ā è̱	ɔaː ɛ	1
-īé̱	īé̱	iːe	1
-ʋ̱̄	ʋ̱̄	uː	9
-ė̱oͮ̄	ė̱oͮ̄	əoː	1
-oͮ̆ʋ̱̄	oͮ̆ʋ̱̄	ouː	1
-ŏ́ʋ̱̄	ŏ́ʋ̱̄	ouː	2
-ʋ̱̀	ʋ̱̀	ʊ	4
-òʋ̱̄	òʋ̱̄	ɔuː	1
-īè	īè	iːɛ	1
-œ̩̄	œ̩̄	øː	1
-ò͋	ò͋	ɔ	1
-ėʋ̃	ėʋ̃	əũ	1
-ėo̱	ėo̱	əo	1
-ă̱ó̃	ă̱ó̃	aõ	1
-ʋ̩̀̃	ʋ̩̀̃	ʊ̃	1
-œ̄́ė̱	œ̄́ė̱	øːə	1
-uͨ̆u̱	uͨ̆u̱	yː	1
-aͤ̆͜ó	aͤ̆͜ó	æo	1
-ṑu̱	ṑu̱	ɔːy	1
-ḗ̩i̱	ḗ̩i̱	eːi	1
-u̱	u̱	y	1
-ō̱	ō̱	oː	1
-ó̩̃	ó̩̃	o	1
-ḕȧ̱	ḕȧ̱	ɛːɐ	1
-ă̩é̱	ă̩é̱	ae	1
-īȯ̱	īȯ̱	iːɔ	1
-òŏ́	òŏ́	ɔo	1
-é̃ĩ	é̃ĩ	ẽɪ̃	3
-é̩̃ĩ̱	é̩̃ĩ̱	ẽi	1
-è̩̃ĩ	è̩̃ĩ	ɛ̃ɪ̃	1
-aͦó	aͦó	ɒo	1
-œ̆́͜u̱	œ̆́͜u̱	øy	1
-œͦ̄ʋ̱ͧ	œͦ̄ʋ̱ͧ	ɞːʉ	1
-œ́œ̱̃	œ́œ̱̃	øː	1
-ĩė̱	ĩė̱	ɪ̃ə	1
-c̱̑	c̱̑	x	1
-ė̱̩	ė̱̩	ə	3
-è̱ā̃	è̱ā̃	ɛãː	3
-ò̱ṓ	ò̱ṓ	ɔoː	1
-ò͜aͦ̄	ò͜aͦ̄	ɔɒː	1
-ŏ̩́ă̩	ŏ̩́ă̩	oa	1
-ṓė	ṓė	oːə	1
-ŏ́ė̱	ŏ́ė̱	oə	1
-ā̀ò̱	ā̀ò̱	aːɔ	1
-a̩ͤi	a̩ͤi	æi	1
-ĕi	ĕi	ei	4
-ă̩ḕ̱	ă̩ḕ̱	aɛː	1
-òi	òi	ɔi	1
-ė̱ė̃	ė̱ė̃	ə̃ː	1
-ĕ̩i̱	ĕ̩i̱	ei	2
-īė̱̃	īė̱̃	iːə	1
-ã͜è̃	ã͜è̃	ãɛ̃	1
-è̱aͤ̃	è̱aͤ̃	ɛæ̃	1
-è̱̃ã	è̱̃ã	ɛã	1
-t̄s	t̄s	tsː	1
-yà̱	y à̱	j a	1
-é͜i	é͜i	ei	2
-à̩	à̩	a	1
-gͩ	gͩ	g	3
-a̱ò	a̱ò	aɔ	3
-a̱ó͜ʋ̱	a̱ ó͜ʋ̱	a ou	1
-a̩͜ó̱	a̩͜ó̱	ao	1
-ò̱̩œ̩̄	ò̱̩œ̩̄	ɔøː	1
-ò̱ṑ	ò̱ṑ	ɔː	1
-ŏ̩̀œ̆̀	ŏ̩̀œ̆̀	ɔœ	1
-œʋ̱ͧ	œʋ̱ͧ	øʉ	1
-z̄	z̄	zː	1
-ū̩ė	ū̩ė	ʏə	1
-è̱è̃	è̱è̃	ɛ̃ː	1
-a̱é	a̱é	ae	1
-a̩ʋ̆	a̩ʋ̆	au	1
-oͮ̄ó̱	oͮ̄ó̱	oːo	1
-uͨ̄ă	uͨ̄ă	yːa	1
-œ̄ė̱	œ̄ė̱	øːə	1
-ăḗ̩	ăḗ̩	aeː	1
-ʋ̄é̱	ʋ̄é̱	uːe	1
-ȯ̱̩ʋ̄̀	ȯ̱̩ʋ̄̀	ɔʊː	1
-ʋ̀ė̱	ʋ̀ė̱	ʊə	2
-à̱è̃	à̱è̃	aɛ̃	1
-e̩i̱	e̩i̱	ei	1
-é̩i̱	é̩i̱	ei	2
-e̩ͥ̄	e̩ͥ̄	e	1
-éa̱	éa̱	ea	1
-aͤè̱	aͤè̱	æɛ	1
-i͜ė̱	i͜ė̱	iə	1
-ė̱͜é	ė̱͜é	əe	1
-ŏ̀ò̃	ŏ̀ò̃	ɔ̃ː	1
-ūằ	ūằ	ỹːa	1
-u̩a̩	u̩a̩	ya	1
-ŭ̩͜ĕ̀	ŭ̩͜ĕ̀	yɛ	1
-ṑò̱	ṑò̱	ɔːɔ	1
-ṓă	ṓă	oːa	1
-ṓʋ	ṓꭒ	oːu	1
-ŭ̩è̩	ŭ̩è̩	yɛ	1
-óė̱	óė̱	oə	3
-œ̀i̱	œ̀i̱	œi	1
-eͥ̆i̱	eͥ̆i̱	ei	1
-ʋ̩̄ȯ̱	ʋ̩̄ȯ̱	uːɔ	1
-aͤ͜œ̄̀	aͤ͜œ̄̀	æœː	1
-ă̩oͮ̆	ă̩oͮ̆	ao	1
-ā̩́ĕ̀	ā̩́ĕ̀	ɑːɛ	1
-o̱͜	o̱͜	o	1
-iĕ́	iĕ́	ie	1
-i͜é	i͜é	ie	1
-ié	ié	ie	1
-ó̩ă	ó̩ă	oa	1
-ȳ	ȳ	jː	1
-oͮʋ	oͮꭒ	ou	1
-óè̱	óè̱	oɛ	1
-o̱͜ā	o̱͜ā	oaː	1
-āo̱͜è̱	ā o̱͜è̱	aː oɛ	1
-ae	ae	ae	1
-a̩ͦ̃ʋ̱̃	a̩ͦ̃ʋ̱̃	ɑu	1
-è̱ȧ	è̱ȧ	ɛɐ	1
-ằè̱	ằè̱	aɛ	1
-ua	ua	ya	1
-œ̱̀ṓ	œ̱̀ṓ	œoː	1
-a̱ẽ	a̱ẽ	aẽ	1
-aͦ̃͜ë̃	aͦ̃͜ë̃	ɑɛ	1
-ṑi	ṑi	ɔːi	1
-ė̱ằ	ė̱ằ	əa	1
-^dj͛i	dj͛ i	dʒ i	1
-^dy̓	dy̓	dʒʲ	1
-^djĭ	dj ĭ	dʒ ɪ	1
-^dj͛	dj͛	dʒ	1
-a̱õ	a̱õ	aõ	1
-a̱ó̃	a̱ó̃	aõ	1
+Grapheme	Graphemes	IPA	Frequency	Sound_Types	CLTS
+^	NULL	NULL	29296		
+y	y	j	3602	consonant	voiced palatal approximant consonant
+ė	ė	ə	3654	vowel	unrounded mid central vowel
++	+	+	21760	marker	+
+f	f	f	2914	consonant	voiceless labio-dental fricative consonant
+ā	ā	aː	1767	vowel	long unrounded open front vowel
+$	NULL	NULL	29760		
+ĭ	ĭ	ɪ	1745	vowel	unrounded near-close near-front vowel
+ṑ	ṑ	ɔː	475	vowel	long rounded open-mid back vowel
+aͦ̄	aͦ̄	ɒː	585	vowel	long rounded open back vowel
+éi̱	éi̱	ei	127	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ā́	ā́	ɑː	583	vowel	long unrounded open back vowel
+è	è	ɛ	2846	vowel	unrounded open-mid front vowel
+ṓ	ṓ	oː	509	vowel	long rounded close-mid back vowel
+é	é	e	1125	vowel	unrounded close-mid front vowel
+ĕ	ĕ	e	806	vowel	unrounded close-mid front vowel
+i	i	i	1372	vowel	unrounded close front vowel
+ë	ë	ɛ	541	vowel	unrounded open-mid front vowel
+e	e	e	283	vowel	unrounded close-mid front vowel
+eͥ	eͥ	e	232	vowel	unrounded close-mid front vowel
+ĕ́i̱	ĕ́i̱	ei	89	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ḗ	ḗ	eː	943	vowel	long unrounded close-mid front vowel
+ï	ï	ɪ	161	vowel	unrounded near-close near-front vowel
+ṯ	ṯ	t	32	consonant	voiceless alveolar stop consonant
+ĕ́	ĕ́	e	353	vowel	unrounded close-mid front vowel
+a͜ó	a͜ó	ao	69	diphthong	from unrounded open front to rounded close-mid back diphthong
+ăó	ăó	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+aͦ͜ó	aͦ͜ó	ɒo	5	diphthong	from rounded open back to rounded close-mid back diphthong
+a	a	a	6526	vowel	unrounded open front vowel
+ĕ̀	ĕ̀	ɛ	4361	vowel	unrounded open-mid front vowel
+ḕ	ḕ	ɛː	989	vowel	long unrounded open-mid front vowel
+aͤ	aͤ	æ	532	vowel	unrounded near-open front vowel
+aͤ̄	aͤ̄	æː	675	vowel	long unrounded near-open front vowel
+ts	ts	ts	1795	consonant	voiceless alveolar sibilant affricate consonant
+ŏ́	ŏ́	o	164	vowel	rounded close-mid back vowel
+b	b	b	2073	consonant	voiced bilabial stop consonant
+è̃ĩ̱	è̃ĩ̱	ɛ̃i	302	diphthong	from nasalized unrounded open-mid front to unrounded close front diphthong
+ṣ	ṣ	θ	528	consonant	voiceless dental fricative consonant
+ó	ó	o	487	vowel	rounded close-mid back vowel
+oͮ	oͮ	o	118	vowel	rounded close-mid back vowel
+ŏ̀	ŏ̀	ɔ	1855	vowel	rounded open-mid back vowel
+ō	ō	oː	111	vowel	long rounded close-mid back vowel
+t	t	t	4667	consonant	voiceless alveolar stop consonant
+tṣ	tṣ	tθ	4	consonant	voiceless dental affricate consonant
+oʋ̱	oʋ̱	ou	12	diphthong	from rounded close-mid back to rounded close back diphthong
+tc̵	tc̵	tʃ	911	consonant	voiceless post-alveolar sibilant affricate consonant
+óʋ̱	óʋ̱	ou	33	diphthong	from rounded close-mid back to rounded close back diphthong
+ĩ	ĩ	ɪ̃	97	vowel	nasalized unrounded near-close near-front vowel
+òʋ	òꭒ	ɔu	21	diphthong	from rounded open-mid back to rounded close back diphthong
+w	w	w	1756	consonant	voiced labio-velar approximant consonant
+v	v	v	3962	consonant	voiced labio-dental fricative consonant
+ē	ē	eː	297	vowel	long unrounded close-mid front vowel
+v̱	v̱	vː	119	consonant	long voiced labio-dental fricative consonant
+è̃i̱	è̃i̱	ɛ̃i	3	diphthong	from nasalized unrounded open-mid front to unrounded close front diphthong
+ắ	ắ	ɑ	142	vowel	unrounded open back vowel
+ắè̱	ắè̱	ɑɛ	4	diphthong	from unrounded open back to unrounded open-mid front diphthong
+ĕ̀i̱	ĕ̀i̱	ɛi	10	diphthong	from unrounded open-mid front to unrounded close front diphthong
+aͦ̃	aͦ̃	ɑ	108	vowel	unrounded open back vowel
+ă	ă	a	4338	vowel	unrounded open front vowel
+ei̱	ei̱	ei	135	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ăè̱	ăè̱	aɛ	17	diphthong	from unrounded open front to unrounded open-mid front diphthong
+aͤé̱	aͤé̱	æe	3	diphthong	from unrounded near-open front to unrounded close-mid front diphthong
+aͤi̱	aͤi̱	æi	69	diphthong	from unrounded near-open front to unrounded close front diphthong
+ĕi̱	ĕi̱	ei	25	diphthong	from unrounded close-mid front to unrounded close front diphthong
+k	k	k	3192	consonant	voiceless velar stop consonant
+ç̱̑	ç̱̑	ç	44	consonant	voiceless palatal sibilant fricative consonant
+eé̱	eé̱	eː	1	vowel	long unrounded close-mid front vowel
+ă͜è̱	ă͜è̱	aɛ	3	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ằ	ằ	a	378	vowel	unrounded open front vowel
+a͜é	a͜é	ae	61	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ẅ	ẅ	ɥ	221	consonant	voiced labio-palatal approximant consonant
+d	d	d	6521	consonant	voiced alveolar stop consonant
+j	j	ʒ	977	consonant	voiced post-alveolar sibilant fricative consonant
+ʋ̆	ʋ̆	u	1322	vowel	rounded close back vowel
+ḏ	ḏ	d	5	consonant	voiced alveolar stop consonant
+œ	œ	ø	60	vowel	rounded close-mid front vowel
+ã	ã	ã	1842	vowel	nasalized unrounded open front vowel
+ŭ	ŭ	y	551	vowel	rounded close front vowel
+ò	ò	ɔ	665	vowel	rounded open-mid back vowel
+y̱	y̱	j	278	consonant	voiced palatal approximant consonant
+o	o	o	104	vowel	rounded close-mid back vowel
+œ́	œ́	ø	299	vowel	rounded close-mid front vowel
+ẖ	ẖ	h	41	consonant	voiceless glottal fricative consonant
+œu̱	œu̱	øy	113	diphthong	from rounded close-mid front to rounded close front diphthong
+tç̑	tç̑	cç	116	consonant	voiceless palatal affricate consonant
+ṉ̇	ṉ̇	ŋ	336	consonant	voiced velar nasal consonant
+t̮	t̮	tʲ	398	consonant	palatalized voiceless alveolar stop consonant
+œ̄	œ̄	øː	105	vowel	long rounded close-mid front vowel
+œ̄̀	œ̄̀	œː	53	vowel	long rounded open-mid front vowel
+œ̆̀	œ̆̀	œ	296	vowel	rounded open-mid front vowel
+l	l	l	8601	consonant	voiced alveolar lateral approximant consonant
+s	s	s	3455	consonant	voiceless alveolar sibilant fricative consonant
+-	-	NULL	409		
+l̆̍	l̆̍	lʲ	68	consonant	palatalized voiced alveolar lateral approximant consonant
+l̮	l̮	ʎ	1218	consonant	voiced palatal lateral approximant consonant
+ò̃	ò̃	ɔ̃	2287	vowel	nasalized rounded open-mid back vowel
+õ	õ	õ	96	vowel	nasalized rounded close-mid back vowel
+ṉ	ṉ	n	221	consonant	voiced alveolar nasal consonant
+ė̱ò̃	ė̱ò̃	əɔ̃	21	diphthong	from unrounded mid central to nasalized rounded open-mid back diphthong
+ʋ̱̃	ʋ̱̃	ũ	2	vowel	nasalized rounded close back vowel
+ò̃ʋ̱̃	ò̃ʋ̱̃	ɔ̃u	6	diphthong	from nasalized rounded open-mid back to rounded close back diphthong
+ó̃	ó̃	õ	151	vowel	nasalized rounded close-mid back vowel
+ʋ̃	ʋ̃	ũ	57	vowel	nasalized rounded close back vowel
+ʋ̀̃	ʋ̀̃	ʊ̃	105	vowel	nasalized rounded near-close near-back vowel
+ì̃	ì̃	ɪ̃	73	vowel	nasalized unrounded near-close near-front vowel
+è̃	è̃	ɛ̃	1357	vowel	nasalized unrounded open-mid front vowel
+ã͜ẽ̱ĩ̱	ã͜ẽ̱ ĩ̱	ãẽ ɪ̃	1	unknownsound	
+ã̱ó̃	ã̱ó̃	aõ	2	diphthong	from unrounded open front to nasalized rounded close-mid back diphthong
+ù̃	ù̃	ỹ	14	vowel	nasalized rounded close front vowel
+aͤ̆	aͤ̆	æ	309	vowel	unrounded near-open front vowel
+œ̀̃	œ̀̃	œ̃	70	vowel	nasalized rounded open-mid front vowel
+è̄̃	è̄̃	ɛ̃ː	137	vowel	long nasalized unrounded open-mid front vowel
+è̃͜ĩ̱	è̃͜ĩ̱	ɛ̃ɪ̃	1	diphthong	from nasalized unrounded open-mid front to nasalized unrounded near-close near-front diphthong
+è̃è̱	è̃è̱	ɛ̃ɛ	1	diphthong	from nasalized unrounded open-mid front to unrounded open-mid front diphthong
+ẽ	ẽ	ẽ	28	vowel	nasalized unrounded close-mid front vowel
+aͤ̃	aͤ̃	æ̃	116	vowel	nasalized unrounded near-open front vowel
+é̃ĩ̱	é̃ĩ̱	ẽi	83	diphthong	from nasalized unrounded close-mid front to unrounded close front diphthong
+āè̱	āè̱	aːɛ	231	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+aͦ̄è̱	aͦ̄è̱	ɒːɛ	67	diphthong	from long rounded open back to unrounded open-mid front diphthong
+aͤ̄è̱	aͤ̄è̱	æːɛ	4	diphthong	from long unrounded near-open front to unrounded open-mid front diphthong
+á̃	á̃	ã	61	vowel	nasalized unrounded open front vowel
+n	n	n	4265	consonant	voiced alveolar nasal consonant
+ʋ̆̀	ʋ̆̀	ʊ	85	vowel	rounded near-close near-back vowel
+ŏ	ŏ	o	373	vowel	rounded close-mid back vowel
+n̄	n̄	nː	132	consonant	long voiced alveolar nasal consonant
+ʋ̇	ʋ̇	ʊ	51	vowel	rounded near-close near-back vowel
+ʋ	ꭒ	u	503	vowel	rounded close back vowel
+a̱	a̱	a	843	vowel	unrounded open front vowel
+ȯ	ȯ	ɔ	181	vowel	rounded open-mid back vowel
+w̱	w̱	w	141	consonant	voiced labio-velar approximant consonant
+à	à	a	32	vowel	unrounded open front vowel
+ʋ̩̆	ʋ̩̆	u	47	vowel	rounded close back vowel
+ă̩	ă̩	a	148	vowel	unrounded open front vowel
+z	z	z	968	consonant	voiced alveolar sibilant fricative consonant
+a͜eͥ	a͜eͥ	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+a̱aͤ̄	a̱aͤ̄	aæː	3	diphthong	from unrounded open front to long unrounded near-open front diphthong
+c̵	c̵	ʃ	1194	consonant	voiceless post-alveolar sibilant fricative consonant
+èi	èi	ɛi	27	diphthong	from unrounded open-mid front to unrounded close front diphthong
+c̵̾	c̵̾	ʃ	357	consonant	voiceless post-alveolar sibilant fricative consonant
+j͛	j͛	ʒ	163	consonant	voiced post-alveolar sibilant fricative consonant
+ī	ī	iː	1060	vowel	long unrounded close front vowel
+ĕ́i	ĕ́i	ei	14	diphthong	from unrounded close-mid front to unrounded close front diphthong
+éi	éi	ei	9	diphthong	from unrounded close-mid front to unrounded close front diphthong
+āė̱	āė̱	aːə	8	diphthong	from long unrounded open front to unrounded mid central diphthong
+ãõ̱	ãõ̱	ão	5	diphthong	from nasalized unrounded open front to rounded close-mid back diphthong
+ā̀	ā̀	aː	217	vowel	long unrounded open front vowel
+p	p	p	4479	consonant	voiceless bilabial stop consonant
+ç̑	ç̑	ç	564	consonant	voiceless palatal sibilant fricative consonant
+ū	ū	yː	200	vowel	long rounded close front vowel
+œ̄́	œ̄́	øː	275	vowel	long rounded close-mid front vowel
+u	u	y	430	vowel	rounded close front vowel
+aȯ̱	aȯ̱	aɔ	2	diphthong	from unrounded open front to rounded open-mid back diphthong
+āȯ̱	āȯ̱	aːɔ	4	diphthong	from long unrounded open front to rounded open-mid back diphthong
+y̆	y̆	ʝ	12	consonant	voiced palatal fricative consonant
+aͤ͜ŏ́	aͤ͜ŏ́	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ṣ̍	ṣ̍	θˡ	31	consonant	with-lateral-release voiceless dental fricative consonant
+a͜o	a͜o	ao	14	diphthong	from unrounded open front to rounded close-mid back diphthong
+a͜ʋ̀	a͜ʋ̀	aʊ	2	diphthong	from unrounded open front to rounded near-close near-back diphthong
+ȧʋ̱	ȧʋ̱	ɐu	50	diphthong	from unrounded near-open central to rounded close back diphthong
+œͦ̆ʋ̱ͧ	œͦ̆ʋ̱ͧ	ɞʉ	28	diphthong	from rounded open-mid central to rounded close central diphthong
+œ̆̀ʋͧ	œ̆̀ʋͧ	œʉ	1	diphthong	from rounded open-mid front to rounded close central diphthong
+pf	pf	pf	7	consonant	voiceless labio-dental affricate consonant
+ʋͧ	ʋͧ	ʉ	36	vowel	rounded close central vowel
+ḏz	ḏz	dz	52	consonant	voiced alveolar sibilant affricate consonant
+e̱ͥ	e̱ͥ	e	87	vowel	unrounded close-mid front vowel
+ʋ̄	ʋ̄	uː	622	vowel	long rounded close back vowel
+ŏ̩̀	ŏ̩̀	ɔ	101	vowel	rounded open-mid back vowel
+ā̀o̱	ā̀o̱	aːo	2	diphthong	from long unrounded open front to rounded close-mid back diphthong
+œ̆́	œ̆́	ø	28	vowel	rounded close-mid front vowel
+k̮	k̮	kʲ	49	consonant	palatalized voiceless velar stop consonant
+k̮ͭ	k̮ͭ	c	32	consonant	voiceless palatal stop consonant
+ė̱	ė̱	ə	1765	vowel	unrounded mid central vowel
+œ̀	œ̀	œ	62	vowel	rounded open-mid front vowel
+ë̱	ë̱	ɛ	191	vowel	unrounded open-mid front vowel
+è̱	è̱	e	1291	vowel	unrounded close-mid front vowel
+aͦ	aͦ	ɒ	103	vowel	rounded open back vowel
+^dz	^dz	dz	289	consonant	voiced alveolar sibilant affricate consonant
+r	r	r	9314	consonant	voiced alveolar trill consonant
+ẓ	ẓ	ð	255	consonant	voiced dental fricative consonant
+ṟ	ṟ	r	131	consonant	voiced alveolar trill consonant
+œ̆	œ̆	ø	34	vowel	rounded close-mid front vowel
+œͦ̆	œͦ̆	ɞ	27	vowel	rounded open-mid central vowel
+^dj͛ẅaͤ	dj͛ ẅ aͤ	dʒ ɥ æ	1	unknownsound	
+^dj	dj	dʒ	167	consonant	voiced post-alveolar sibilant affricate consonant
+ḗè̱	ḗè̱	eːɛ	14	diphthong	from long unrounded close-mid front to unrounded open-mid front diphthong
+ī̀	ī̀	ɪː	46	vowel	long unrounded near-close near-front vowel
+īė̱	īė̱	iːə	246	diphthong	from long unrounded close front to unrounded mid central diphthong
+iė̱	iė̱	iə	7	diphthong	from unrounded close front to unrounded mid central diphthong
+īë̱	īë̱	iːɛ	74	diphthong	from long unrounded close front to unrounded open-mid front diphthong
+a͜è	a͜è	aɛ	112	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ā́è̱	ā́è̱	ɑːɛ	113	diphthong	from long unrounded open back to unrounded open-mid front diphthong
+ā̀è̱	ā̀è̱	aːɛ	8	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+aͤ̄i̱	aͤ̄i̱	æːi	6	diphthong	from long unrounded near-open front to unrounded close front diphthong
+aͤĭ	aͤĭ	æɪ	1	diphthong	from unrounded near-open front to unrounded near-close near-front diphthong
+āi̱	āi̱	aːi	17	diphthong	from long unrounded open front to unrounded close front diphthong
+aͤi	aͤi	æi	86	diphthong	from unrounded near-open front to unrounded close front diphthong
+·	·	NULL	53	unknownsound	
+ī̩è	ī̩è	iːɛ	2	diphthong	from long unrounded close front to unrounded open-mid front diphthong
+ḵ	ḵ	k	45	consonant	voiceless velar stop consonant
+a͜é̱	a͜é̱	ae	40	diphthong	from unrounded open front to unrounded close-mid front diphthong
+āé̱	āé̱	aːe	19	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+n̮	n̮	ɲ	410	consonant	voiced palatal nasal consonant
+ʋ̄̀	ʋ̄̀	ʊː	32	vowel	long rounded near-close near-back vowel
+èė̱	èė̱	ɛə	13	diphthong	from unrounded open-mid front to unrounded mid central diphthong
+oͮʋ̱	oͮʋ̱	ou	9	diphthong	from rounded close-mid back to rounded close back diphthong
+ŏ́ʋ	ŏ́ꭒ	ou	4	diphthong	from rounded close-mid back to rounded close back diphthong
+aͦó̱	aͦó̱	ɒo	2	diphthong	from rounded open back to rounded close-mid back diphthong
+ʋ̱	ʋ̱	u	238	vowel	rounded close back vowel
+ā̩	ā̩	aː	34	vowel	long unrounded open front vowel
+a͜ʋ̆	a͜ʋ̆	au	3	diphthong	from unrounded open front to rounded close back diphthong
+ʋ̄œ̱̃	ʋ̄œ̱̃	uːø	1	diphthong	from long rounded close back to rounded close-mid front diphthong
+ṙ	ṙ	ʀ	352	consonant	voiced uvular trill consonant
+ï̱	ï̱	ɪ	10	vowel	unrounded near-close near-front vowel
+aͦ͜ó̱	aͦ͜ó̱	ɒo	3	diphthong	from rounded open back to rounded close-mid back diphthong
+a̱ḕ	a̱ḕ	aɛː	32	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+ă͜è	ă͜è	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+a͜aͤ	a͜aͤ	aæ	1	diphthong	from unrounded open front to unrounded near-open front diphthong
+aͤ̆i	aͤ̆i	æi	13	diphthong	from unrounded near-open front to unrounded close front diphthong
+ī̩è̱	ī̩è̱	iːɛ	13	diphthong	from long unrounded close front to unrounded open-mid front diphthong
+ĕ̩̀	ĕ̩̀	ɛ	209	vowel	unrounded open-mid front vowel
+ăé̱	ăé̱	ae	9	diphthong	from unrounded open front to unrounded close-mid front diphthong
+a͜aͤ̄	a͜aͤ̄	aæː	1	diphthong	from unrounded open front to long unrounded near-open front diphthong
+aè̱	aè̱	aɛ	32	diphthong	from unrounded open front to unrounded open-mid front diphthong
+aͤ̆i̱	aͤ̆i̱	æi	13	diphthong	from unrounded near-open front to unrounded close front diphthong
+aͤ̄i	aͤ̄i	æːi	1	diphthong	from long unrounded near-open front to unrounded close front diphthong
+ā̀e̱	ā̀e̱	aːe	28	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+aé̱	aé̱	ae	17	diphthong	from unrounded open front to unrounded close-mid front diphthong
+aͦ̄ė̱	aͦ̄ė̱	ɒːə	2	diphthong	from long rounded open back to unrounded mid central diphthong
+ā́ė̱	ā́ė̱	ɑːə	6	diphthong	from long unrounded open back to unrounded mid central diphthong
+m	m	m	3434	consonant	voiced bilabial nasal consonant
+ã̱è̃	ã̱è̃	aɛ̃	11	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+ė̃	ė̃	ə̃	53	vowel	nasalized unrounded mid central vowel
+āe̱ͥ	āe̱ͥ	aːe	3	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ī̩	ī̩	iː	34	vowel	long unrounded close front vowel
+h	h	h	73	consonant	voiceless glottal fricative consonant
+ṛ	ṛ	ɾ	23	consonant	voiced alveolar tap consonant
+aè	aè	aɛ	30	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ḕi̱	ḕi̱	ɛːi	6	diphthong	from long unrounded open-mid front to unrounded close front diphthong
+a͜ē̩	a͜ē̩	aeː	1	diphthong	from unrounded open front to long unrounded close-mid front diphthong
+ai̱	ai̱	ai	16	diphthong	from unrounded open front to unrounded close front diphthong
+d̄	d̄	dː	6	consonant	long voiced alveolar stop consonant
+ằi̱	ằi̱	ai	2	diphthong	from unrounded open front to unrounded close front diphthong
+i̱	i̱	i	39	vowel	unrounded close front vowel
+a̩ͤ̄	a̩ͤ̄	æː	14	vowel	long unrounded near-open front vowel
+āè	āè	aːɛ	21	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+ei	ei	ei	30	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ēè̱	ēè̱	eːɛ	4	diphthong	from long unrounded close-mid front to unrounded open-mid front diphthong
+aͤ̄ï̱	aͤ̄ï̱	æːɪ	1	diphthong	from long unrounded near-open front to unrounded near-close near-front diphthong
+a͜ḗ̩	a͜ḗ̩	aeː	1	diphthong	from unrounded open front to long unrounded close-mid front diphthong
+e̱	e̱	e	122	vowel	unrounded close-mid front vowel
+ā́ë̱	ā́ë̱	ɑːɛ	1	diphthong	from long unrounded open back to unrounded open-mid front diphthong
+āe̱	āe̱	aːe	10	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+dz	dz	dz	923	consonant	voiced alveolar sibilant affricate consonant
+ăŏ́	ăŏ́	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+i̩	i̩	ɪ	23	vowel	unrounded near-close near-front vowel
+ṑó̱	ṑó̱	ɔːo	10	diphthong	from long rounded open-mid back to rounded close-mid back diphthong
+á	á	ɑ	54	vowel	unrounded open back vowel
+œ̱ò̃	œ̱ò̃	øɔ̃	4	diphthong	from rounded close-mid front to nasalized rounded open-mid back diphthong
+a̩ó̱	a̩ó̱	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+a͜ó̩	a͜ó̩	ao	3	diphthong	from unrounded open front to rounded close-mid back diphthong
+dẓ	dẓ	dð	3	consonant	voiced dental affricate consonant
+áò̱	áò̱	ɑɔ	4	diphthong	from unrounded open back to rounded open-mid back diphthong
+aò̱	aò̱	aɔ	46	diphthong	from unrounded open front to rounded open-mid back diphthong
+āò̱	āò̱	aːɔ	101	diphthong	from long unrounded open front to rounded open-mid back diphthong
+aͦ̄ò̱	aͦ̄ò̱	ɒːɔ	10	diphthong	from long rounded open back to rounded open-mid back diphthong
+aͤ̆ó	aͤ̆ó	æo	2	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+a͜ō	a͜ō	aoː	2	diphthong	from unrounded open front to long rounded close-mid back diphthong
+ă͜ʋ̆̀	ă͜ʋ̆̀	aʊ	1	diphthong	from unrounded open front to rounded near-close near-back diphthong
+œʋ̱	œʋ̱	øu	1	diphthong	from rounded close-mid front to rounded close back diphthong
+œ́u̱	œ́u̱	øy	19	diphthong	from rounded close-mid front to rounded close front diphthong
+œͦ̆u̱	œͦ̆u̱	ɞy	10	diphthong	from rounded open-mid central to rounded close front diphthong
+ȯœ̱́	ȯœ̱́	ɔø	2	diphthong	from rounded open-mid back to rounded close-mid front diphthong
+œ̆̀u̱	œ̆̀u̱	œy	24	diphthong	from rounded open-mid front to rounded close front diphthong
+œͦ̆ʋ̱	œͦ̆ʋ̱	ɞu	28	diphthong	from rounded open-mid central to rounded close back diphthong
+œ̆u̱	œ̆u̱	øy	4	diphthong	from rounded close-mid front to rounded close front diphthong
+ŏ́ʋ̱	ŏ́ʋ̱	ou	69	diphthong	from rounded close-mid back to rounded close back diphthong
+œ̀u̱	œ̀u̱	œy	53	diphthong	from rounded open-mid front to rounded close front diphthong
+ā̀ó	ā̀ó	aːo	1	diphthong	from long unrounded open front to rounded close-mid back diphthong
+à̱	à̱	a	31	vowel	unrounded open front vowel
+à̃	à̃	ã	98	vowel	nasalized unrounded open front vowel
+ãõ	ãõ	ãõ	2	diphthong	from nasalized unrounded open front to nasalized rounded close-mid back diphthong
+ḏẓ	ḏẓ	dz	6	consonant	voiced alveolar sibilant affricate consonant
+ṅ	ṅ	ŋ	9	consonant	voiced velar nasal consonant
+ā̀ó̱	ā̀ó̱	aːo	11	diphthong	from long unrounded open front to rounded close-mid back diphthong
+é̃	é̃	ẽ	14	vowel	nasalized unrounded close-mid front vowel
+é̃i̱	é̃i̱	ẽi	4	diphthong	from nasalized unrounded close-mid front to unrounded close front diphthong
+ḗi̱	ḗi̱	eːi	22	diphthong	from long unrounded close-mid front to unrounded close front diphthong
+œ́ė̱̃	œ́ė̱̃	øə	2	diphthong	from rounded close-mid front to unrounded mid central diphthong
+aé	aé	ae	8	diphthong	from unrounded open front to unrounded close-mid front diphthong
+aͦ̆	aͦ̆	ɒ	28	vowel	rounded open back vowel
+aͦ̄ë̱	aͦ̄ë̱	ɒːɛ	2	diphthong	from long rounded open back to unrounded open-mid front diphthong
+āë̱	āë̱	aːɛ	3	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+ae̱	ae̱	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+a̱͜è	a̱͜è	aɛ	11	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ė̩	ė̩	ə	141	vowel	unrounded mid central vowel
+u̇	u̇	ʏ	47	vowel	rounded near-close near-front vowel
+a̩	a̩	a	47	vowel	unrounded open front vowel
+ë̩	ë̩	ɛ	16	vowel	unrounded open-mid front vowel
+ŭ̩̀	ŭ̩̀	ʏ	3	vowel	rounded near-close near-front vowel
+oͮ̆	oͮ̆	o	33	vowel	rounded close-mid back vowel
+ʋ̩̇	ʋ̩̇	ʊ	3	vowel	rounded near-close near-back vowel
+l̷	l̷	ʟ	54	consonant	voiced velar lateral approximant consonant
+ȯ̱	ȯ̱	ɔ	190	vowel	rounded open-mid back vowel
+œ̩̆̀	œ̩̆̀	œ	19	vowel	rounded open-mid front vowel
+a̩ͦ̄	a̩ͦ̄	ɑː	6	vowel	long unrounded open back vowel
+ē̩	ē̩	eː	6	vowel	long unrounded close-mid front vowel
+ā̀é	ā̀é	aːe	1	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ĕ̇	ĕ̇	e	2	vowel	unrounded close-mid front vowel
+ā̩è̱	ā̩è̱	aːɛ	5	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+ā̩́è̱	ā̩́è̱	ɑːɛ	3	diphthong	from long unrounded open back to unrounded open-mid front diphthong
+ă̩ì	ă̩ì	aɪ	1	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ằé̱	ằé̱	ae	3	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ė̱oͮ	ė̱oͮ	əo	1	diphthong	from unrounded mid central to rounded close-mid back diphthong
+ʋ̄ė̱̃	ʋ̄ė̱̃	uːə	1	diphthong	from long rounded close back to unrounded mid central diphthong
+èi̱	èi̱	ɛi	23	diphthong	from unrounded open-mid front to unrounded close front diphthong
+a͜e	a͜e	ae	15	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ăĭ	ăĭ	aɪ	4	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ėi̱	ėi̱	əi	2	diphthong	from unrounded mid central to unrounded close front diphthong
+ā́é̱	ā́é̱	ɑːe	2	diphthong	from long unrounded open back to unrounded close-mid front diphthong
+ẏ̱	ẏ̱	ʁ	1	consonant	voiced uvular fricative consonant
+a͜ē	a͜ē	aeː	1	diphthong	from unrounded open front to long unrounded close-mid front diphthong
+ŏ̀i̱	ŏ̀i̱	ɔi	3	diphthong	from rounded open-mid back to unrounded close front diphthong
+ai	ai	ai	9	diphthong	from unrounded open front to unrounded close front diphthong
+ā͜è	ā͜è	aːɛ	6	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+ằe̱	ằe̱	ae	2	diphthong	from unrounded open front to unrounded close-mid front diphthong
+aĭ	aĭ	aɪ	1	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ḕ̩	ḕ̩	ɛː	24	vowel	long unrounded open-mid front vowel
+ò̱	ò̱	ɔ	338	vowel	rounded open-mid back vowel
+o̱	o̱	o	181	vowel	rounded close-mid back vowel
+ŏ̩̀i̱	ŏ̩̀i̱	ɔi	1	diphthong	from rounded open-mid back to unrounded close front diphthong
+ó̱	ó̱	o	5	vowel	rounded close-mid back vowel
+ḗ̩	ḗ̩	eː	14	vowel	long unrounded close-mid front vowel
+r̄	r̄	rː	43	consonant	long voiced alveolar trill consonant
+a̱ó	a̱ó	ao	10	diphthong	from unrounded open front to rounded close-mid back diphthong
+ò̱͜ó	ò̱͜ó	ɔo	8	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+a̱͜e	a̱͜e	ae	7	diphthong	from unrounded open front to unrounded close-mid front diphthong
+aó	aó	ao	24	diphthong	from unrounded open front to rounded close-mid back diphthong
+ā̩́	ā̩́	ɑː	9	vowel	long unrounded open back vowel
+āó̱	āó̱	aːo	10	diphthong	from long unrounded open front to rounded close-mid back diphthong
+òó̱	òó̱	ɔo	2	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+ĕ̀é̱	ĕ̀é̱	ɛe	1	diphthong	from unrounded open-mid front to unrounded close-mid front diphthong
+ā́e̱	ā́e̱	ɑːe	1	diphthong	from long unrounded open back to unrounded close-mid front diphthong
+a͜ò	a͜ò	aɔ	60	diphthong	from unrounded open front to rounded open-mid back diphthong
+ă͜ŏ́	ă͜ŏ́	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+ȧʋ	ȧꭒ	ɐu	5	diphthong	from unrounded near-open central to rounded close back diphthong
+óʋ	óꭒ	ou	5	diphthong	from rounded close-mid back to rounded close back diphthong
+a̱ͦó	a̱ͦó	ɒo	1	diphthong	from rounded open back to rounded close-mid back diphthong
+à͜ė	à͜ė	aə	1	diphthong	from unrounded open front to unrounded mid central diphthong
+ằĭ	ằĭ	aɪ	1	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ằė̱	ằė̱	aə	1	diphthong	from unrounded open front to unrounded mid central diphthong
+ī̩ė̱	ī̩ė̱	iːə	3	diphthong	from long unrounded close front to unrounded mid central diphthong
+īè̱	īè̱	iːɛ	183	diphthong	from long unrounded close front to unrounded open-mid front diphthong
+ēi̱	ēi̱	eːi	1	diphthong	from long unrounded close-mid front to unrounded close front diphthong
+ằ͜ĭ̀	ằ͜ĭ̀	aɪ	1	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ằi	ằi	ai	8	diphthong	from unrounded open front to unrounded close front diphthong
+g	g	g	606	consonant	voiced velar stop consonant
+y̆̍	y̆̍	j	37	consonant	voiced palatal approximant consonant
+ẓ̍	ẓ̍	ðˡ	16	consonant	with-lateral-release voiced dental fricative consonant
+é̱	é̱	e	50	vowel	unrounded close-mid front vowel
+d̮	d̮	dʲ	132	consonant	palatalized voiced alveolar stop consonant
+a̱ṑ	a̱ṑ	aɔː	23	diphthong	from unrounded open front to long rounded open-mid back diphthong
+oͮ̄	oͮ̄	oː	51	vowel	long rounded close-mid back vowel
+èè̱	èè̱	ɛː	1	vowel	long unrounded open-mid front vowel
+a͜ó̱	a͜ó̱	ao	40	diphthong	from unrounded open front to rounded close-mid back diphthong
+aó̱	aó̱	ao	16	diphthong	from unrounded open front to rounded close-mid back diphthong
+ū̩̀	ū̩̀	ʏː	2	vowel	long rounded near-close near-front vowel
+ʋ̩̄	ʋ̩̄	uː	31	vowel	long rounded close back vowel
+ė̱ʋ̄̀	ė̱ʋ̄̀	əʊː	1	diphthong	from unrounded mid central to long rounded near-close near-back diphthong
+a͜ò̱	a͜ò̱	aɔ	32	diphthong	from unrounded open front to rounded open-mid back diphthong
+ăŏ̀	ăŏ̀	aɔ	1	diphthong	from unrounded open front to rounded open-mid back diphthong
+ăoͮ	ăoͮ	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+è̃ė̱	è̃ė̱	ɛ̃ə	1	diphthong	from nasalized unrounded open-mid front to unrounded mid central diphthong
+è̃a̱	è̃a̱	ɛ̃a	1	diphthong	from nasalized unrounded open-mid front to unrounded open front diphthong
+oͮ̄ʋ̱	oͮ̄ʋ̱	oːu	2	diphthong	from long rounded close-mid back to rounded close back diphthong
+ē̃	ē̃	ẽː	1	vowel	long nasalized unrounded close-mid front vowel
+ò͜ó	ò͜ó	ɔo	10	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+ăó̃	ăó̃	aõ	2	diphthong	from unrounded open front to nasalized rounded close-mid back diphthong
+ʋ̩̄ė̱	ʋ̩̄ė̱	uːə	1	diphthong	from long rounded close back to unrounded mid central diphthong
+oʋ	oꭒ	ou	8	diphthong	from rounded close-mid back to rounded close back diphthong
+ṓʋ̱	ṓʋ̱	oːu	24	diphthong	from long rounded close-mid back to rounded close back diphthong
+a̱ó̩	a̱ó̩	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+ṓė̱	ṓė̱	oːə	20	diphthong	from long rounded close-mid back to unrounded mid central diphthong
+ʋ̄ė̱	ʋ̄ė̱	uːə	45	diphthong	from long rounded close back to unrounded mid central diphthong
+ë̄	ë̄	ɛː	20	vowel	long unrounded open-mid front vowel
+œ̀i	œ̀i	œi	2	diphthong	from rounded open-mid front to unrounded close front diphthong
+ū̀	ū̀	ʏː	44	vowel	long rounded near-close near-front vowel
+ĕ́ă	ĕ́ă	ea	2	diphthong	from unrounded close-mid front to unrounded open front diphthong
+ḗė̱	ḗė̱	eːə	14	diphthong	from long unrounded close-mid front to unrounded mid central diphthong
+éė̱	éė̱	eə	1	diphthong	from unrounded close-mid front to unrounded mid central diphthong
+ù	ù	ʏ	21	vowel	rounded near-close near-front vowel
+è̩	è̩	ɛ	44	vowel	unrounded open-mid front vowel
+ū̩ė̱	ū̩ė̱	ʏə	1	diphthong	from rounded near-close near-front to unrounded mid central diphthong
+ė͜i	ė͜i	əi	1	diphthong	from unrounded mid central to unrounded close front diphthong
+u̇ė̱	u̇ė̱	ʏə	1	diphthong	from rounded near-close near-front to unrounded mid central diphthong
+ŭ̩è̱	ŭ̩è̱	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+g̱	g̱	g	21	consonant	voiced velar stop consonant
+è͋	è͋	ɛ	9	vowel	unrounded open-mid front vowel
+ĭ̩t̮è	ĭ̩ t̮ è	i t e	1	unknownsound	
+i̱ė	i̱ė	iə	1	diphthong	from unrounded close front to unrounded mid central diphthong
+a̱è̃	a̱è̃	aɛ̃	42	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+è̩̃	è̩̃	ɛ̃	26	vowel	nasalized unrounded open-mid front vowel
+tç̵̑	tç̵̑	tɕ	31	consonant	voiceless alveolo-palatal sibilant affricate consonant
+óï	óï	oɪ	1	diphthong	from rounded close-mid back to unrounded near-close near-front diphthong
+aͤ͜è̱	aͤ͜è̱	æɛ	1	diphthong	from unrounded near-open front to unrounded open-mid front diphthong
+ắe̱	ắe̱	ɑe	1	diphthong	from unrounded open back to unrounded close-mid front diphthong
+ăi̱	ăi̱	ai	2	diphthong	from unrounded open front to unrounded close front diphthong
+œ̩̄́	œ̩̄́	øː	7	vowel	long rounded close-mid front vowel
+a̱è̄̃	a̱è̄̃	aɛ̃ː	11	diphthong	from unrounded open front to long nasalized unrounded open-mid front diphthong
+è̩̄̃	è̩̄̃	ɛ̃ː	7	vowel	long nasalized unrounded open-mid front vowel
+a͜a	a͜a	aː	1	vowel	long unrounded open front vowel
+ā̃	ā̃	ãː	134	vowel	long nasalized unrounded open front vowel
+ã̩	ã̩	ã	37	vowel	nasalized unrounded open front vowel
+è̩̃ĩ̱	è̩̃ĩ̱	ɛ̃i	10	diphthong	from nasalized unrounded open-mid front to unrounded close front diphthong
+a̱aͤ̃	a̱aͤ̃	aæ̃	2	diphthong	from unrounded open front to nasalized unrounded near-open front diphthong
+l̄	l̄	lː	62	consonant	long voiced alveolar lateral approximant consonant
+ĕ̩	ĕ̩	e	18	vowel	unrounded close-mid front vowel
+ė̩a	ė̩a	əa	1	diphthong	from unrounded mid central to unrounded open front diphthong
+ëa	ëa	ɛa	1	diphthong	from unrounded open-mid front to unrounded open front diphthong
+œ̀̃õ̱	œ̀̃õ̱	œ̃o	1	diphthong	from nasalized rounded open-mid front to rounded close-mid back diphthong
+ë̩o̱	ë̩o̱	ɛo	1	diphthong	from unrounded open-mid front to rounded close-mid back diphthong
+ĭ̀	ĭ̀	ɪ	53	vowel	unrounded near-close near-front vowel
+œ̆̀͜oͮ	œ̆̀͜oͮ	œo	1	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ëi̱	ëi̱	ɛi	1	diphthong	from unrounded open-mid front to unrounded close front diphthong
+œ̄u̱	œ̄u̱	øːy	8	diphthong	from long rounded close-mid front to rounded close front diphthong
+ooͮ̄	ooͮ̄	oː	1	vowel	long rounded close-mid back vowel
+ẅ̑	ẅ̑	ɥ	27	consonant	voiced labio-palatal approximant consonant
+uͨ	uͨ	y	8	vowel	rounded close front vowel
+ẽĩ̱	ẽĩ̱	ẽi	23	diphthong	from nasalized unrounded close-mid front to unrounded close front diphthong
+ā̀é̱	ā̀é̱	aːe	9	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ò̄̃	ò̄̃	ɔ̃ː	24	vowel	long nasalized rounded open-mid back vowel
+sãtc̵̾ç̑é	s ã tc̵̾ç̑ é	s ã tʃ ɛ	1	unknownsound	
+è̱ã	è̱ã	ɛã	11	diphthong	from unrounded open-mid front to nasalized unrounded open front diphthong
+è̩i	è̩i	ɛi	1	diphthong	from unrounded open-mid front to unrounded close front diphthong
+ī̩a	ī̩a	iːa	16	diphthong	from long unrounded close front to unrounded open front diphthong
+a̩͜è	a̩͜è	aɛ	2	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ă͜eͥ	ă͜eͥ	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+r̥	r̥	r	14	consonant	voiced alveolar trill consonant
+ie̱	ie̱	ie	2	diphthong	from unrounded close front to unrounded close-mid front diphthong
+ài̱	ài̱	ai	1	diphthong	from unrounded open front to unrounded close front diphthong
+dy̓	dy̓	dʒʲ	13	consonant	palatalized voiced post-alveolar sibilant affricate consonant
+i̩a	i̩a	ɪa	30	diphthong	from unrounded near-close near-front to unrounded open front diphthong
+a͜è̱	a͜è̱	aɛ	11	diphthong	from unrounded open front to unrounded open-mid front diphthong
+i̩ȯ̱	i̩ȯ̱	ɪɔ	2	diphthong	from unrounded near-close near-front to rounded open-mid back diphthong
+é̩i	é̩i	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ăe̱ͥ	ăe̱ͥ	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ʋė̱	ꭒė̱	uə	9	diphthong	from rounded close back to unrounded mid central diphthong
+s̄	s̄	sː	1	consonant	long voiceless alveolar sibilant fricative consonant
+eaͤ̆	eaͤ̆	eæ	1	diphthong	from unrounded close-mid front to unrounded near-open front diphthong
+ĕ̀ĕ̀	ĕ̀ĕ̀	ɛː	1	vowel	long unrounded open-mid front vowel
+è͜è	è͜è	ɛː	3	vowel	long unrounded open-mid front vowel
+ăĕ̀	ăĕ̀	aɛ	4	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ă͜ó	ă͜ó	ao	6	diphthong	from unrounded open front to rounded close-mid back diphthong
+ā́ò̱	ā́ò̱	ɑːɔ	20	diphthong	from long unrounded open back to rounded open-mid back diphthong
+ă͜ó̱	ă͜ó̱	ao	12	diphthong	from unrounded open front to rounded close-mid back diphthong
+ŏ̀͜ó̱	ŏ̀͜ó̱	ɔo	2	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+ă͜e̱	ă͜e̱	ae	3	diphthong	from unrounded open front to unrounded close-mid front diphthong
+a͜e̱	a͜e̱	ae	5	diphthong	from unrounded open front to unrounded close-mid front diphthong
+èé̱	èé̱	ɛe	2	diphthong	from unrounded open-mid front to unrounded close-mid front diphthong
+a̱͜ḕ	a̱͜ḕ	aɛː	8	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+ʋ̩	ʋ̩	u	6	vowel	rounded close back vowel
+a͜oͮ	a͜oͮ	ao	6	diphthong	from unrounded open front to rounded close-mid back diphthong
+o̱ͮ	o̱ͮ	o	8	vowel	rounded close-mid back vowel
+ėò̃	ėò̃	əɔ̃	2	diphthong	from unrounded mid central to nasalized rounded open-mid back diphthong
+uͨu̱	uͨu̱	yː	2	vowel	long rounded close front vowel
+a̱ò̃	a̱ò̃	aɔ̃	24	diphthong	from unrounded open front to nasalized rounded open-mid back diphthong
+u͜ằ	u͜ằ	ya	1	diphthong	from rounded close front to unrounded open front diphthong
+yʋ͜ă	y ʋ͜ă	j ua	1	unknownsound	
+o͜ă	o͜ă	oa	2	diphthong	from rounded close-mid back to unrounded open front diphthong
+ūė̱	ūė̱	yːə	96	diphthong	from long rounded close front to unrounded mid central diphthong
+ă͜oͮ	ă͜oͮ	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+a̱aͦ̄	a̱aͦ̄	aɒː	3	diphthong	from unrounded open front to long rounded open back diphthong
+a̩ͤ͜ŏ́	a̩ͤ͜ŏ́	æo	2	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+œ̄œ̱́	œ̄œ̱́	øːø	1	diphthong	from long rounded close-mid front to rounded close-mid front diphthong
+œ̆̀ʋ̱ͧ	œ̆̀ʋ̱ͧ	œʉ	10	diphthong	from rounded open-mid front to rounded close central diphthong
+ãò̱̃	ãò̱̃	ãɔ	5	diphthong	from nasalized unrounded open front to rounded open-mid back diphthong
+ãó̱̃	ãó̱̃	ão	14	diphthong	from nasalized unrounded open front to rounded close-mid back diphthong
+œ̆͜ò̃	œ̆͜ò̃	øɔ̃	1	diphthong	from rounded close-mid front to nasalized rounded open-mid back diphthong
+ūa	ūa	ỹːa	5	diphthong	from long nasalized rounded close front to unrounded open front diphthong
+ė̱i	ė̱i	əi	1	diphthong	from unrounded mid central to unrounded close front diphthong
+īa̱	īa̱	iːa	22	diphthong	from long unrounded close front to unrounded open front diphthong
+īa	īa	iːa	7	diphthong	from long unrounded close front to unrounded open front diphthong
+ẅ̱	ẅ̱	ɥ	14	consonant	voiced labio-palatal approximant consonant
+ŭ̀a	ŭ̀a	ʏa	1	diphthong	from rounded near-close near-front to unrounded open front diphthong
+ĭ̩	ĭ̩	i	22	vowel	unrounded close front vowel
+ă͜ḕ̩	ă͜ḕ̩	aɛː	1	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+a͜é̩	a͜é̩	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+à͜è̱	à͜è̱	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+a͜i	a͜i	ai	3	diphthong	from unrounded open front to unrounded close front diphthong
+ăi	ăi	ai	6	diphthong	from unrounded open front to unrounded close front diphthong
+ĕ̀i	ĕ̀i	ɛi	8	diphthong	from unrounded open-mid front to unrounded close front diphthong
+ĕ́͜i̱	ĕ́͜i̱	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+a̱͜é	a̱͜é	ae	3	diphthong	from unrounded open front to unrounded close-mid front diphthong
+aͤ͜è	aͤ͜è	æɛ	1	diphthong	from unrounded near-open front to unrounded open-mid front diphthong
+ā́è	ā́è	ɑːɛ	5	diphthong	from long unrounded open back to unrounded open-mid front diphthong
+ae̱ͥ	ae̱ͥ	ae	2	diphthong	from unrounded open front to unrounded close-mid front diphthong
+œ͜u̱	œ͜u̱	øy	2	diphthong	from rounded close-mid front to rounded close front diphthong
+œ̄̀œ̱́	œ̄̀œ̱́	œːø	1	diphthong	from long rounded open-mid front to rounded close-mid front diphthong
+tc̵̾	tc̵̾	tʃ	61	consonant	voiceless post-alveolar sibilant affricate consonant
+ò͜ă	ò͜ă	ɔa	1	diphthong	from rounded open-mid back to unrounded open front diphthong
+œ̆́u̱	œ̆́u̱	øy	3	diphthong	from rounded close-mid front to rounded close front diphthong
+ì	ì	ɪ	35	vowel	unrounded near-close near-front vowel
+œ̆̀ā	œ̆̀ā	œaː	2	diphthong	from rounded open-mid front to long unrounded open front diphthong
+ëā	ëā	ɛaː	1	diphthong	from unrounded open-mid front to long unrounded open front diphthong
+œ̆̀o	œ̆̀o	œo	1	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ā͜ò̱	ā͜ò̱	aːɔ	1	diphthong	from long unrounded open front to rounded open-mid back diphthong
+ŏ̀ʋ̱	ŏ̀ʋ̱	ɔu	2	diphthong	from rounded open-mid back to rounded close back diphthong
+è̃ĩ	è̃ĩ	ɛ̃ɪ̃	14	diphthong	from nasalized unrounded open-mid front to nasalized unrounded near-close near-front diphthong
+ăè̃	ăè̃	aɛ̃	1	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+m̱	m̱	m	21	consonant	voiced bilabial nasal consonant
+ya͜é̱	y a͜é̱	j ae	1	unknownsound	
+ă͜é̱	ă͜é̱	ae	5	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ãè̱̃	ãè̱̃	ãɛ	5	diphthong	from nasalized unrounded open front to unrounded open-mid front diphthong
+ĩ̱	ĩ̱	ɪ̃	35	vowel	nasalized unrounded near-close near-front vowel
+ā̩̃	ā̩̃	ãː	7	vowel	long nasalized unrounded open front vowel
+aͤ̃ĩ̱	aͤ̃ĩ̱	æ̃i	4	diphthong	from nasalized unrounded near-open front to unrounded close front diphthong
+d̯	d̯	d	19	consonant	voiced alveolar stop consonant
+ò̩ʋ̱	ò̩ʋ̱	ɔu	1	diphthong	from rounded open-mid back to rounded close back diphthong
+ŏ̱	ŏ̱	o	2	vowel	rounded close-mid back vowel
+ò͜ó̱	ò͜ó̱	ɔo	13	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+œ̆̀͜ò̃	œ̆̀͜ò̃	œɔ̃	1	diphthong	from rounded open-mid front to nasalized rounded open-mid back diphthong
+á̱	á̱	ɑ	6	vowel	unrounded open back vowel
+ḕė̱	ḕė̱	ɛːə	1	diphthong	from long unrounded open-mid front to unrounded mid central diphthong
+è̱͜é	è̱͜é	ɛe	2	diphthong	from unrounded open-mid front to unrounded close-mid front diphthong
+aͤ̄e̱	aͤ̄e̱	æːe	1	diphthong	from long unrounded near-open front to unrounded close-mid front diphthong
+ḗă	ḗă	eːa	8	diphthong	from long unrounded close-mid front to unrounded open front diphthong
+uͨù̱	uͨù̱	yʏ	1	diphthong	from rounded close front to rounded near-close near-front diphthong
+ā̩́ò̱	ā̩́ò̱	ɑːɔ	1	diphthong	from long unrounded open back to rounded open-mid back diphthong
+a̱ͤ͜ó	a̱ͤ͜ó	æo	3	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+a̩͜ó	a̩͜ó	ao	4	diphthong	from unrounded open front to rounded close-mid back diphthong
+œ̀ʋ̱ͧ	œ̀ʋ̱ͧ	œʉ	20	diphthong	from rounded open-mid front to rounded close central diphthong
+ūo̱	ūo̱	ỹːo	2	diphthong	from long nasalized rounded close front to rounded close-mid back diphthong
+o̱ā	o̱ā	oaː	2	diphthong	from rounded close-mid back to long unrounded open front diphthong
+ʋ̱ͧ	ʋ̱ͧ	ʉ	1	vowel	rounded close central vowel
+ã̱	ã̱	ã	10	vowel	nasalized unrounded open front vowel
+ũ	ũ	ỹ	8	vowel	nasalized rounded close front vowel
+ʋ̀	ʋ̀	ʊ	17	vowel	rounded near-close near-back vowel
+uė̱	uė̱	yə	3	diphthong	from rounded close front to unrounded mid central diphthong
+è̄̃ĩ̱	è̄̃ĩ̱	ɛ̃ːi	9	diphthong	from long nasalized unrounded open-mid front to unrounded close front diphthong
+i̩a̩	i̩a̩	ɪa	3	diphthong	from unrounded near-close near-front to unrounded open front diphthong
+ī̩ò̱	ī̩ò̱	iːɔ	3	diphthong	from long unrounded close front to rounded open-mid back diphthong
+a̩ͤ̆	a̩ͤ̆	æ	6	vowel	unrounded near-open front vowel
+œͦ̄	œͦ̄	ɞː	2	vowel	long rounded open-mid central vowel
+t̯	t̯	t	6	consonant	voiceless alveolar stop consonant
+tʋ͜è	t ʋ͜è	t ue	1	unknownsound	
+ă̩è̱	ă̩è̱	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+āï̱	āï̱	aːɪ	1	diphthong	from long unrounded open front to unrounded near-close near-front diphthong
+īò̱	īò̱	iːɔ	5	diphthong	from long unrounded close front to rounded open-mid back diphthong
+ë̩̆	ë̩̆	ɛ	2	vowel	unrounded open-mid front vowel
+ī̩e̱	ī̩e̱	iːe	1	diphthong	from long unrounded close front to unrounded close-mid front diphthong
+ī̩a̱	ī̩a̱	iːa	7	diphthong	from long unrounded close front to unrounded open front diphthong
+l̮̱	l̮̱	ʎ	46	consonant	voiced palatal lateral approximant consonant
+ëė̱	ëė̱	ɛə	1	diphthong	from unrounded open-mid front to unrounded mid central diphthong
+aͦè̱	aͦè̱	ɒɛ	5	diphthong	from rounded open back to unrounded open-mid front diphthong
+œ͜ù	œ͜ù	øʏ	1	diphthong	from rounded close-mid front to rounded near-close near-front diphthong
+a̩ͤ͜ó	a̩ͤ͜ó	æo	4	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ōœ̱̀	ōœ̱̀	oːœ	1	diphthong	from long rounded close-mid back to rounded open-mid front diphthong
+e̱i	e̱i	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ṓ̩	ṓ̩	oː	23	vowel	long rounded close-mid back vowel
+ā͜è̱	ā͜è̱	aːɛ	2	diphthong	from long unrounded open front to unrounded open-mid front diphthong
+ṑ̩r	ṑ̩ r	o r	10	unknownsound	
+n̯	n̯	n	2	consonant	voiced alveolar nasal consonant
+ʋ̄ȯ̱	ʋ̄ȯ̱	uːɔ	11	diphthong	from long rounded close back to rounded open-mid back diphthong
+eͥi̱	eͥi̱	ei	7	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ḗa̱	ḗa̱	eːa	1	diphthong	from long unrounded close-mid front to unrounded open front diphthong
+èo	èo	ɛo	1	diphthong	from unrounded open-mid front to rounded close-mid back diphthong
+l̯	l̯	l	4	consonant	voiced alveolar lateral approximant consonant
+ç̵̑	ç̵̑	ɕ	7	consonant	voiceless alveolo-palatal sibilant fricative consonant
+e̩ͥ	e̩ͥ	e	3	vowel	unrounded close-mid front vowel
+ė̱é	ė̱é	əe	4	diphthong	from unrounded mid central to unrounded close-mid front diphthong
+ĕ̩́i̱	ĕ̩́i̱	ei	2	diphthong	from unrounded close-mid front to unrounded close front diphthong
+a̱ͦ	a̱ͦ	ɒ	10	vowel	rounded open back vowel
+ă̱͜ĕ̀	ă̱͜ĕ̀	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ao̱	ao̱	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+ă̩͜è	ă̩͜è	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ăe̱	ăe̱	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ò̱ó	ò̱ó	ɔo	10	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+aʋ̀	aʋ̀	aʊ	2	diphthong	from unrounded open front to rounded near-close near-back diphthong
+ṓò̱	ṓò̱	oːɔ	1	diphthong	from long rounded close-mid back to rounded open-mid back diphthong
+ʋ̄è̱	ʋ̄è̱	uːɛ	8	diphthong	from long rounded close back to unrounded open-mid front diphthong
+e̩ͥ̄i̱	e̩ͥ̄i̱	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+eͥ̄	eͥ̄	eː	22	vowel	long unrounded close-mid front vowel
+ė̱é̩	ė̱é̩	əe	1	diphthong	from unrounded mid central to unrounded close-mid front diphthong
+ằ̱	ằ̱	a	1	vowel	unrounded open front vowel
+ă̱	ă̱	a	1	vowel	unrounded open front vowel
+œ̀u	œ̀u	œy	9	diphthong	from rounded open-mid front to rounded close front diphthong
+aò	aò	aɔ	19	diphthong	from unrounded open front to rounded open-mid back diphthong
+ă̩ḗ	ă̩ḗ	aeː	1	diphthong	from unrounded open front to long unrounded close-mid front diphthong
+ăó̱	ăó̱	ao	7	diphthong	from unrounded open front to rounded close-mid back diphthong
+a̩ͦ	a̩ͦ	ɑ	2	vowel	unrounded open back vowel
+œ̩̆	œ̩̆	ø	2	vowel	rounded close-mid front vowel
+ă̩ó̱	ă̩ó̱	ao	4	diphthong	from unrounded open front to rounded close-mid back diphthong
+œ̩̀ṓ	œ̩̀ṓ	œoː	1	diphthong	from rounded open-mid front to long rounded close-mid back diphthong
+ŏ̀œ̱́	ŏ̀œ̱́	ɔø	1	diphthong	from rounded open-mid back to rounded close-mid front diphthong
+a̩͜ṑ	a̩͜ṑ	aɔː	1	diphthong	from unrounded open front to long rounded open-mid back diphthong
+ʋ̩̄̀	ʋ̩̄̀	u	2	vowel	rounded close back vowel
+ūè̱	ūè̱	ỹːɛ	8	diphthong	from long nasalized rounded close front to unrounded open-mid front diphthong
+œœ̱́	œœ̱́	øː	1	vowel	long rounded close-mid front vowel
+ĕã	ĕã	eã	1	diphthong	from unrounded close-mid front to nasalized unrounded open front diphthong
+ëã	ëã	ɛã	1	diphthong	from unrounded open-mid front to nasalized unrounded open front diphthong
+ĕ̀ã	ĕ̀ã	ɛã	2	diphthong	from unrounded open-mid front to nasalized unrounded open front diphthong
+o̩ͮă	o̩ͮă	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+è̱à̃	è̱à̃	ɛã	3	diphthong	from unrounded open-mid front to nasalized unrounded open front diphthong
+aͤ͋	aͤ͋	æ	3	vowel	unrounded near-open front vowel
+ã̱ò̃	ã̱ò̃	ãɔ̃	19	diphthong	from nasalized unrounded open front to nasalized rounded open-mid back diphthong
+ãó̃	ãó̃	ãõ	1	diphthong	from nasalized unrounded open front to nasalized rounded close-mid back diphthong
+ŭ̀	ŭ̀	ʏ	50	vowel	rounded near-close near-front vowel
+ȧ	ȧ	ɐ	20	vowel	unrounded near-open central vowel
+ḻ	ḻ	l	10	consonant	voiced alveolar lateral approximant consonant
+œ́ʋ̱	œ́ʋ̱	øu	1	diphthong	from rounded close-mid front to rounded close back diphthong
+c̑	c̑	x	5	consonant	voiceless velar fricative consonant
+œ̱̀	œ̱̀	œ	1	vowel	rounded open-mid front vowel
+ȯ̩	ȯ̩	ɔ	4	vowel	rounded open-mid back vowel
+aʋ̱̀	aʋ̱̀	aʊ	1	diphthong	from unrounded open front to rounded near-close near-back diphthong
+ū̩a̱	ū̩a̱	ʏa	1	diphthong	from rounded near-close near-front to unrounded open front diphthong
+ʋ̩̄a̱	ʋ̩̄a̱	uːa	5	diphthong	from long rounded close back to unrounded open front diphthong
+ằ̩	ằ̩	a	11	vowel	unrounded open front vowel
+ʋ̩a	ʋ̩a	ua	3	diphthong	from rounded close back to unrounded open front diphthong
+oă̩	oă̩	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+u͜a̩	u͜a̩	ya	1	diphthong	from rounded close front to unrounded open front diphthong
+ʋ̄a̱	ʋ̄a̱	uːa	21	diphthong	from long rounded close back to unrounded open front diphthong
+e̩	e̩	e	3	vowel	unrounded close-mid front vowel
+j̱	j̱	ʒ	2	consonant	voiced post-alveolar sibilant fricative consonant
+œ̱̀͜ŏ́	œ̱̀͜ŏ́	œo	3	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ĕ́ė̱	ĕ́ė̱	eə	1	diphthong	from unrounded close-mid front to unrounded mid central diphthong
+ḕé̱	ḕé̱	ɛːe	9	diphthong	from long unrounded open-mid front to unrounded close-mid front diphthong
+ȧu̱	ȧu̱	ɐy	1	diphthong	from unrounded near-open central to rounded close front diphthong
+i͜ằ	i͜ằ	ia	1	diphthong	from unrounded close front to unrounded open front diphthong
+a̱͜ó	a̱͜ó	ao	7	diphthong	from unrounded open front to rounded close-mid back diphthong
+eͥ̆	eͥ̆	e	36	vowel	unrounded close-mid front vowel
+i͜ë	i͜ë	iɛ	1	diphthong	from unrounded close front to unrounded open-mid front diphthong
+ò̩̃	ò̩̃	ɔ̃	15	vowel	nasalized rounded open-mid back vowel
+āa	āa	aːa	1	diphthong	from long unrounded open front to unrounded open front diphthong
+āa̱	āa̱	aːa	2	diphthong	from long unrounded open front to unrounded open front diphthong
+āo̱	āo̱	aːo	3	diphthong	from long unrounded open front to rounded close-mid back diphthong
+a̱͜ṑ	a̱͜ṑ	aɔː	4	diphthong	from unrounded open front to long rounded open-mid back diphthong
+ōė̱	ōė̱	oːə	3	diphthong	from long rounded close-mid back to unrounded mid central diphthong
+ë̱͜ó	ë̱͜ó	ɛo	1	diphthong	from unrounded open-mid front to rounded close-mid back diphthong
+ŏ̀͜œ̱́	ŏ̀͜œ̱́	ɔø	1	diphthong	from rounded open-mid back to rounded close-mid front diphthong
+œ̩u̱	œ̩u̱	øy	1	diphthong	from rounded close-mid front to rounded close front diphthong
+i͜ĕ	i͜ĕ	ie	1	diphthong	from unrounded close front to unrounded close-mid front diphthong
+œ̀oͮ	œ̀oͮ	œo	2	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+œ̆̀œ̱́	œ̆̀œ̱́	œø	2	diphthong	from rounded open-mid front to rounded close-mid front diphthong
+a͜o̱	a͜o̱	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+ò̱͜oͮ	ò̱͜oͮ	ɔo	1	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+ŏ́a	ŏ́a	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+ĕ̀ī	ĕ̀ī	ɛiː	3	diphthong	from unrounded open-mid front to long unrounded close front diphthong
+aĕ̀	aĕ̀	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ŏ̩	ŏ̩	o	19	vowel	rounded close-mid back vowel
+œ̀͜u	œ̀͜u	œy	1	diphthong	from rounded open-mid front to rounded close front diphthong
+aͤ̆͜ŏ́	aͤ̆͜ŏ́	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+a͜ḕ	a͜ḕ	aɛː	1	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+œ̱̀͜i	œ̱̀͜i	œi	2	diphthong	from rounded open-mid front to unrounded close front diphthong
+a͜ʋ̱	a͜ʋ̱	au	1	diphthong	from unrounded open front to rounded close back diphthong
+ā̩̀	ā̩̀	aː	3	vowel	long unrounded open front vowel
+u̩	u̩	y	9	vowel	rounded close front vowel
+ū̩	ū̩	ʏ	11	vowel	rounded near-close near-front vowel
+u͜à̱	u͜à̱	ya	1	diphthong	from rounded close front to unrounded open front diphthong
+u͜a	u͜a	ya	1	diphthong	from rounded close front to unrounded open front diphthong
+ūë̱	ūë̱	ỹːɛ	4	diphthong	from long nasalized rounded close front to unrounded open-mid front diphthong
+ʋ̩̆i̱	ʋ̩̆i̱	ui	1	diphthong	from rounded close back to unrounded close front diphthong
+oͮ̄è̱	oͮ̄è̱	oːɛ	2	diphthong	from long rounded close-mid back to unrounded open-mid front diphthong
+oͮe̱ͥ	oͮe̱ͥ	oe	1	diphthong	from rounded close-mid back to unrounded close-mid front diphthong
+a̩ͤ	a̩ͤ	æ	1	vowel	unrounded near-open front vowel
+ʋ̄é	ʋ̄é	uːe	1	diphthong	from long rounded close back to unrounded close-mid front diphthong
+ŭ͜è	ŭ͜è	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+uė	uė	yə	1	diphthong	from rounded close front to unrounded mid central diphthong
+i̩ė̱	i̩ė̱	ɪə	2	diphthong	from unrounded near-close near-front to unrounded mid central diphthong
+ŭ̩	ŭ̩	y	735	vowel	rounded close front vowel
+ēé̱	ēé̱	eːe	2	diphthong	from long unrounded close-mid front to unrounded close-mid front diphthong
+ăʋ̆̀	ăʋ̆̀	aʊ	1	diphthong	from unrounded open front to rounded near-close near-back diphthong
+ò̱œ̄	ò̱œ̄	ɔøː	8	diphthong	from rounded open-mid back to long rounded close-mid front diphthong
+œ̀œ̱́	œ̀œ̱́	œø	1	diphthong	from rounded open-mid front to rounded close-mid front diphthong
+ȯu̱	ȯu̱	ɔy	1	diphthong	from rounded open-mid back to rounded close front diphthong
+o̱ʋ	o̱ꭒ	ou	1	diphthong	from rounded close-mid back to rounded close back diphthong
+s̱	s̱	s	4	consonant	voiceless alveolar sibilant fricative consonant
+ī̀ė̱	ī̀ė̱	ɪːə	4	diphthong	from long unrounded near-close near-front to unrounded mid central diphthong
+ōa	ōa	oːa	1	diphthong	from long rounded close-mid back to unrounded open front diphthong
+óo̱	óo̱	oː	1	vowel	long rounded close-mid back vowel
+ė̩é̱	ė̩é̱	əe	1	diphthong	from unrounded mid central to unrounded close-mid front diphthong
+a̱ͦ͜ṑ	a̱ͦ͜ṑ	ɒɔː	1	diphthong	from rounded open back to long rounded open-mid back diphthong
+œ̀o̱ͮ	œ̀o̱ͮ	œo	5	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ì̩	ì̩	ɪ	3	vowel	unrounded near-close near-front vowel
+ō̩	ō̩	o	6	vowel	rounded close-mid back vowel
+ŏ̩́ă	ŏ̩́ă	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+ă̩ŏ́	ă̩ŏ́	ao	5	diphthong	from unrounded open front to rounded close-mid back diphthong
+yœ̩͜u̱	y œ̩͜u̱	j øy	1	unknownsound	
+aͤ͜oͮ	aͤ͜oͮ	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ya͜ò	y a͜ò	j aɔ	1	unknownsound	
+ya͜ó	y a͜ó	j ao	1	unknownsound	
+œ̄́u̱	œ̄́u̱	øːy	1	diphthong	from long rounded close-mid front to rounded close front diphthong
+yă͜é̱	y ă͜é̱	j ae	1	unknownsound	
+œ̆ŭ̀	œ̆ŭ̀	øʏ	1	diphthong	from rounded close-mid front to rounded near-close near-front diphthong
+o̱œ̄	o̱œ̄	oøː	1	diphthong	from rounded close-mid back to long rounded close-mid front diphthong
+a̩͜ò	a̩͜ò	aɔ	2	diphthong	from unrounded open front to rounded open-mid back diphthong
+a͜ṓ	a͜ṓ	aoː	3	diphthong	from unrounded open front to long rounded close-mid back diphthong
+ʋͧ̄a	ʋͧ̄a	ʉːa	2	diphthong	from long rounded close central to unrounded open front diphthong
+ʋo̱	ꭒo̱	uo	1	diphthong	from rounded close back to rounded close-mid back diphthong
+ï̩	ï̩	ɪ	1	vowel	unrounded near-close near-front vowel
+ā̩ò̱	ā̩ò̱	aːɔ	6	diphthong	from long unrounded open front to rounded open-mid back diphthong
+ṑ̩	ṑ̩	ɔː	4	vowel	long rounded open-mid back vowel
+ò̩	ò̩	ɔ	16	vowel	rounded open-mid back vowel
+é̩	é̩	e	2	vowel	unrounded close-mid front vowel
+ẽ̱	ẽ̱	e	1	vowel	unrounded close-mid front vowel
+z̾	z̾	z̥	3	consonant	devoiced voiced alveolar sibilant fricative consonant
+ãẽ	ãẽ	ãẽ	15	diphthong	from nasalized unrounded open front to nasalized unrounded close-mid front diphthong
+jͨ	jͨ	ʒ	4	consonant	voiced post-alveolar sibilant fricative consonant
+œ̱̀͜ó	œ̱̀͜ó	œo	12	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ăò̃	ăò̃	aɔ̃	1	diphthong	from unrounded open front to nasalized rounded open-mid back diphthong
+è̩̄̃ĩ̱	è̩̄̃ĩ̱	ɛ̃ːi	2	diphthong	from long nasalized unrounded open-mid front to unrounded close front diphthong
+è̩̃i̱	è̩̃i̱	ɛ̃i	1	diphthong	from nasalized unrounded open-mid front to unrounded close front diphthong
+œ̩̀	œ̩̀	œ	1	vowel	rounded open-mid front vowel
+œ̩̀̃	œ̩̀̃	ø	1	vowel	rounded close-mid front vowel
+ė̱̃	ė̱̃	ə̃	1	vowel	nasalized unrounded mid central vowel
+ăḕ	ăḕ	aɛː	1	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+ā̩é̱	ā̩é̱	aːe	1	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ă̩ḕ	ă̩ḕ	aɛː	1	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+a̩ͤi̱	a̩ͤi̱	æi	1	diphthong	from unrounded near-open front to unrounded close front diphthong
+ī̀o	ī̀o	ɪːo	1	diphthong	from long unrounded near-close near-front to rounded close-mid back diphthong
+a̱ē	a̱ē	aeː	2	diphthong	from unrounded open front to long unrounded close-mid front diphthong
+ṓó̱	ṓó̱	oːo	1	diphthong	from long rounded close-mid back to rounded close-mid back diphthong
+là̃	l à̃	l ã	7	unknownsound	
+o̱ã	o̱ã	oã	1	diphthong	from rounded close-mid back to nasalized unrounded open front diphthong
+ḗé̱	ḗé̱	eːe	1	diphthong	from long unrounded close-mid front to unrounded close-mid front diphthong
+ūė	ūė	ỹːə	5	diphthong	from long nasalized rounded close front to unrounded mid central diphthong
+œ̱́ŭ̀	œ̱́ŭ̀	øʏ	1	diphthong	from rounded close-mid front to rounded near-close near-front diphthong
+u͜ė	u͜ė	yə	1	diphthong	from rounded close front to unrounded mid central diphthong
+o̱è̃	o̱è̃	oɛ̃	2	diphthong	from rounded close-mid back to nasalized unrounded open-mid front diphthong
+œ̱̀͜ṓ	œ̱̀͜ṓ	œoː	2	diphthong	from rounded open-mid front to long rounded close-mid back diphthong
+ė̱͜ó	ė̱͜ó	əo	1	diphthong	from unrounded mid central to rounded close-mid back diphthong
+œ̱̀͜ó̩	œ̱̀͜ó̩	œo	1	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ʋ̱̇	ʋ̱̇	ʊ	5	vowel	rounded near-close near-back vowel
+a̱͜ò	a̱͜ò	aɔ	5	diphthong	from unrounded open front to rounded open-mid back diphthong
+ă͜oͮ̆	ă͜oͮ̆	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+yā͜ò̱	y ā͜ò̱	j aːɔ	1	unknownsound	
+œ̩̄̀	œ̩̄̀	ø	2	vowel	rounded close-mid front vowel
+a̱ͤó̩	a̱ͤó̩	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ò̱͜œ	ò̱͜œ	ɔø	1	diphthong	from rounded open-mid back to rounded close-mid front diphthong
+ʋ̩ͧ	ʋ̩ͧ	ʉ	2	vowel	rounded close central vowel
+u̩̇	u̩̇	ʏ	1	vowel	rounded near-close near-front vowel
+ȯ̱ʋ	ȯ̱ꭒ	ɔu	1	diphthong	from rounded open-mid back to rounded close back diphthong
+ʋͧ̆	ʋͧ̆	ʉ	14	vowel	rounded close central vowel
+œ̄́ŭ̩	œ̄́ŭ̩	øːy	1	diphthong	from long rounded close-mid front to rounded close front diphthong
+ă͜ĕ̀	ă͜ĕ̀	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ā͜é̱	ā͜é̱	aːe	2	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ĕ̩́	ĕ̩́	e	3	vowel	unrounded close-mid front vowel
+ò͜è	ò͜è	ɔɛ	2	diphthong	from rounded open-mid back to unrounded open-mid front diphthong
+ŏ̀i	ŏ̀i	ɔi	6	diphthong	from rounded open-mid back to unrounded close front diphthong
+è͋ĩ̱	è͋ĩ̱	ɛi	1	diphthong	from unrounded open-mid front to unrounded close front diphthong
+é͋	é͋	e	1	vowel	unrounded close-mid front vowel
+ḗi	ḗi	eːi	2	diphthong	from long unrounded close-mid front to unrounded close front diphthong
+óă	óă	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+w̄	w̄	wː	2	consonant	long voiced labio-velar approximant consonant
+^na̱ṑ̩va̱	n a̱ṑ̩ v a̱	n aoː v a	2	unknownsound	
+aͤ͜ó	aͤ͜ó	æo	10	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ȯ̱͜œ	ȯ̱͜œ	ɔø	1	diphthong	from rounded open-mid back to rounded close-mid front diphthong
+œ̄̀u̱	œ̄̀u̱	œːy	7	diphthong	from long rounded open-mid front to rounded close front diphthong
+œͦu̱	œͦu̱	ɞy	3	diphthong	from rounded open-mid central to rounded close front diphthong
+œͦ̄o̱ͮ	œͦ̄o̱ͮ	ɞːo	1	diphthong	from long rounded open-mid central to rounded close-mid back diphthong
+ʋ̃a̱	ʋ̃a̱	ũa	1	diphthong	from nasalized rounded close back to unrounded open front diphthong
+ūa̱	ūa̱	ỹːa	5	diphthong	from long nasalized rounded close front to unrounded open front diphthong
+œͧ̄	œͧ̄	øː	1	vowel	long rounded close-mid front vowel
+yà	y à	j a	1	unknownsound	
+ï̩̄	ï̩̄	ɪː	1	vowel	long unrounded near-close near-front vowel
+i̩ò̩̃	i̩ò̩̃	ɪɔ̃	2	diphthong	from unrounded near-close near-front to nasalized rounded open-mid back diphthong
+œ̱̀ò̄̃	œ̱̀ò̄̃	œɔ̃ː	1	diphthong	from rounded open-mid front to long nasalized rounded open-mid back diphthong
+ū̩a	ū̩a	ʏa	4	diphthong	from rounded near-close near-front to unrounded open front diphthong
+ʋ̩a̱	ʋ̩a̱	ua	2	diphthong	from rounded close back to unrounded open front diphthong
+ù̩	ù̩	ʏ	2	vowel	rounded near-close near-front vowel
+ū̀a̱	ū̀a̱	ʏːa	4	diphthong	from long rounded near-close near-front to unrounded open front diphthong
+a̱ͤŏ́	a̱ͤŏ́	æo	2	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ʋ͜ă	ʋ͜ă	ua	1	diphthong	from rounded close back to unrounded open front diphthong
+œͦ̆ʋͧ	œͦ̆ʋͧ	ɞʉ	1	diphthong	from rounded open-mid central to rounded close central diphthong
+ʋͧ̄a̱	ʋͧ̄a̱	ʉːa	1	diphthong	from long rounded close central to unrounded open front diphthong
+ʋ̄a	ʋ̄a	uːa	1	diphthong	from long rounded close back to unrounded open front diphthong
+u̩a	u̩a	ya	2	diphthong	from rounded close front to unrounded open front diphthong
+i̩a̱	i̩a̱	ɪa	4	diphthong	from unrounded near-close near-front to unrounded open front diphthong
+iò̩̃	iò̩̃	iɔ̃	1	diphthong	from unrounded close front to nasalized rounded open-mid back diphthong
+ȧ̱	ȧ̱	ɐ	25	vowel	unrounded near-open central vowel
+ó̩ʋ̱	ó̩ʋ̱	ou	1	diphthong	from rounded close-mid back to rounded close back diphthong
+o̩ʋ	o̩ꭒ	ou	1	diphthong	from rounded close-mid back to rounded close back diphthong
+ã̱é̃	ã̱é̃	aẽ	7	diphthong	from unrounded open front to nasalized unrounded close-mid front diphthong
+iŏ	iŏ	io	1	diphthong	from unrounded close front to rounded close-mid back diphthong
+ȱ	ȱ	ɔː	2	vowel	long rounded open-mid back vowel
+œ̱ò̩̃	œ̱ò̩̃	øɔ̃	1	diphthong	from rounded close-mid front to nasalized rounded open-mid back diphthong
+aʋ	aꭒ	au	6	diphthong	from unrounded open front to rounded close back diphthong
+ă͜i̱	ă͜i̱	ai	1	diphthong	from unrounded open front to unrounded close front diphthong
+œ̱͜ó	œ̱͜ó	øo	3	diphthong	from rounded close-mid front to rounded close-mid back diphthong
+ŏ̀ĕ̀	ŏ̀ĕ̀	ɔɛ	1	diphthong	from rounded open-mid back to unrounded open-mid front diphthong
+òă	òă	ɔa	1	diphthong	from rounded open-mid back to unrounded open front diphthong
+œ̄́ʋ̱	œ̄́ʋ̱	øːu	1	diphthong	from long rounded close-mid front to rounded close back diphthong
+œ̱ū̀	œ̱ū̀	øʏː	2	diphthong	from rounded close-mid front to long rounded near-close near-front diphthong
+a̩ó	a̩ó	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+ăò	ăò	aɔ	2	diphthong	from unrounded open front to rounded open-mid back diphthong
+œͦʋ̱ͧ	œͦʋ̱ͧ	ɞʉ	1	diphthong	from rounded open-mid central to rounded close central diphthong
+ʋͧ̄	ʋͧ̄	ʉː	11	vowel	long rounded close central vowel
+œͧ	œͧ	ø	1	vowel	rounded close-mid front vowel
+ṑ͜ó̱	ṑ͜ó̱	ɔːo	1	diphthong	from long rounded open-mid back to rounded close-mid back diphthong
+ḗ̩ă	ḗ̩ă	eːa	1	diphthong	from long unrounded close-mid front to unrounded open front diphthong
+ʋ̆ė̱̃	ʋ̆ė̱̃	uə	1	diphthong	from rounded close back to unrounded mid central diphthong
+ḕò	ḕò	ɛːɔ	1	diphthong	from long unrounded open-mid front to rounded open-mid back diphthong
+ā̩ò	ā̩ò	aːɔ	1	diphthong	from long unrounded open front to rounded open-mid back diphthong
+a͜ā	a͜ā	aː	1	vowel	long unrounded open front vowel
+oͮā	oͮā	oaː	1	diphthong	from rounded close-mid back to long unrounded open front diphthong
+ʋ̩̄a	ʋ̩̄a	uːa	2	diphthong	from long rounded close back to unrounded open front diphthong
+ʋͧ͜a	ʋͧ͜a	ua	1	diphthong	from rounded close back to unrounded open front diphthong
+ȧ̩	ȧ̩	ɐ	1	vowel	unrounded near-open central vowel
+ʋ̄ò̱	ʋ̄ò̱	uːɔ	3	diphthong	from long rounded close back to rounded open-mid back diphthong
+ʋ̄ė	ʋ̄ė	uːə	1	diphthong	from long rounded close back to unrounded mid central diphthong
+u͜ĕ̀	u͜ĕ̀	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+ʋ̄ë̱	ʋ̄ë̱	uːɛ	6	diphthong	from long rounded close back to unrounded open-mid front diphthong
+r̍	r̍	rˡ	16	consonant	with-lateral-release voiced alveolar trill consonant
+ó͜ă	ó͜ă	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+œ̱̀͜oͮ	œ̱̀͜oͮ	œo	1	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+òʋ̱	òʋ̱	ɔu	8	diphthong	from rounded open-mid back to rounded close back diphthong
+œ̱̀oͮ̄	œ̱̀oͮ̄	œoː	1	diphthong	from rounded open-mid front to long rounded close-mid back diphthong
+ʋ̩̆a̱ͦ̃	ʋ̩̆a̱ͦ̃	uɒ	1	diphthong	from rounded close back to rounded open back diphthong
+ḕa̱	ḕa̱	ɛːa	2	diphthong	from long unrounded open-mid front to unrounded open front diphthong
+oḕ	oḕ	oɛː	1	diphthong	from rounded close-mid back to long unrounded open-mid front diphthong
+éă	éă	ea	1	diphthong	from unrounded close-mid front to unrounded open front diphthong
+ao	ao	ao	3	diphthong	from unrounded open front to rounded close-mid back diphthong
+œ̩̆u̱	œ̩̆u̱	øy	1	diphthong	from rounded close-mid front to rounded close front diphthong
+a̱ͤoͮ	a̱ͤoͮ	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ò̱͜œ̄̀	ò̱͜œ̄̀	ɔœː	3	diphthong	from rounded open-mid back to long rounded open-mid front diphthong
+œͦ̆o̱ͮ	œͦ̆o̱ͮ	ɞo	3	diphthong	from rounded open-mid central to rounded close-mid back diphthong
+œ̆̀o̱ͮ	œ̆̀o̱ͮ	œo	1	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ò͜ʋ	ò͜ꭒ	ɔu	1	diphthong	from rounded open-mid back to rounded close back diphthong
+uͨ̄	uͨ̄	yː	3	vowel	long rounded close front vowel
+ŏ̀ó̱	ŏ̀ó̱	ɔo	2	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+a̱ͤĩ	a̱ͤĩ	æɪ̃	1	diphthong	from unrounded near-open front to nasalized unrounded near-close near-front diphthong
+aḕ	aḕ	aɛː	1	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+aó̃	aó̃	aõ	2	diphthong	from unrounded open front to nasalized rounded close-mid back diphthong
+a͜i̱	a͜i̱	ai	4	diphthong	from unrounded open front to unrounded close front diphthong
+d̯̄	d̯̄	dː	1	consonant	long voiced alveolar stop consonant
+l̷̄	l̷̄	ʟː	2	consonant	long voiced velar lateral approximant consonant
+õ̱	õ̱	õ	1	vowel	nasalized rounded close-mid back vowel
+œ̱̀ʋ̆̀	œ̱̀ʋ̆̀	œʊ	1	diphthong	from rounded open-mid front to rounded near-close near-back diphthong
+ʋ̄́	ʋ̄́	u	1	vowel	rounded close back vowel
+dͭ	dͭ	d̥	12	consonant	devoiced voiced alveolar stop consonant
+áè̱	áè̱	ɑɛ	2	diphthong	from unrounded open back to unrounded open-mid front diphthong
+eͥ̆ă	eͥ̆ă	ea	1	diphthong	from unrounded close-mid front to unrounded open front diphthong
+ēė̱	ēė̱	eːə	4	diphthong	from long unrounded close-mid front to unrounded mid central diphthong
+ãĩ̱	ãĩ̱	ãi	1	diphthong	from nasalized unrounded open front to unrounded close front diphthong
+a̱è̩̃	a̱è̩̃	aɛ̃	2	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+ằè͋	ằè͋	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ĕ̇i̱	ĕ̇i̱	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ā̩é̩	ā̩é̩	aːe	1	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ăa̩ͤ̆	ăa̩ͤ̆	aæ	1	diphthong	from unrounded open front to unrounded near-open front diphthong
+ăī	ăī	aiː	1	diphthong	from unrounded open front to long unrounded close front diphthong
+ăĭ̩	ăĭ̩	aɪ	1	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ãẽ̱	ãẽ̱	ãe	4	diphthong	from nasalized unrounded open front to unrounded close-mid front diphthong
+ë̃	ë̃	ɛ	3	vowel	unrounded open-mid front vowel
+ù̃ė̱	ù̃ė̱	ỹə	1	diphthong	from nasalized rounded close front to unrounded mid central diphthong
+ắ̩	ắ̩	ɑ	4	vowel	unrounded open back vowel
+ï̩̆	ï̩̆	ɪ	1	vowel	unrounded near-close near-front vowel
+ă̩̇	ă̩̇	ɐ	1	vowel	unrounded near-open central vowel
+īȧ̱	īȧ̱	iːɐ	1	diphthong	from long unrounded close front to unrounded near-open central diphthong
+œ̱̀ʋ̄̀	œ̱̀ʋ̄̀	œʊː	1	diphthong	from rounded open-mid front to long rounded near-close near-back diphthong
+ăo̱	ăo̱	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+a̱͜òyè̱	a̱͜ò y è̱	aɔ j ɛ	2	unknownsound	
+eͥ̆i	eͥ̆i	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+a̱͜òy	a̱͜ò y	aɔ j	1	unknownsound	
+œ̱̀ò̃	œ̱̀ò̃	œɔ̃	9	diphthong	from rounded open-mid front to nasalized rounded open-mid back diphthong
+ì̩è̱	ì̩è̱	ɪɛ	1	diphthong	from unrounded near-close near-front to unrounded open-mid front diphthong
+ĕ̱̀	ĕ̱̀	ɛ	3	vowel	unrounded open-mid front vowel
+ʋ̱̩̀	ʋ̱̩̀	u	1	vowel	rounded close back vowel
+ȧ̱è̄̃	ȧ̱è̄̃	ɐɛ̃ː	1	diphthong	from unrounded near-open central to long nasalized unrounded open-mid front diphthong
+c̵͜	c̵͜	ʃ	1	consonant	voiceless post-alveolar sibilant fricative consonant
+a̱̩è̃	a̱̩è̃	aɛ̃	1	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+s͜	s͜	s	1	consonant	voiceless alveolar sibilant fricative consonant
+aͦ̃ė̃	aͦ̃ė̃	ɑə̃	1	diphthong	from unrounded open back to nasalized unrounded mid central diphthong
+àī̩	àī̩	aiː	1	diphthong	from unrounded open front to long unrounded close front diphthong
+oͮ̃	oͮ̃	õ	16	vowel	nasalized rounded close-mid back vowel
+eͥ̃	eͥ̃	ẽ	9	vowel	nasalized unrounded close-mid front vowel
+i̩a̱ͦ	i̩a̱ͦ	ɪɒ	1	diphthong	from unrounded near-close near-front to rounded open back diphthong
+i̩ă̩	i̩ă̩	ɪa	1	diphthong	from unrounded near-close near-front to unrounded open front diphthong
+ī̀è̱	ī̀è̱	ɪːɛ	4	diphthong	from long unrounded near-close near-front to unrounded open-mid front diphthong
+œù̱	œù̱	øʏ	1	diphthong	from rounded close-mid front to rounded near-close near-front diphthong
+a̱ͤó	a̱ͤó	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ò̱͜œ̄	ò̱͜œ̄	ɔøː	2	diphthong	from rounded open-mid back to long rounded close-mid front diphthong
+ȧ̩ʋ	ȧ̩ꭒ	ɐu	1	diphthong	from unrounded near-open central to rounded close back diphthong
+ʋ̄a̱ͦ	ʋ̄a̱ͦ	uːɒ	1	diphthong	from long rounded close back to rounded open back diphthong
+ʋ̩̄a̩	ʋ̩̄a̩	uːa	1	diphthong	from long rounded close back to unrounded open front diphthong
+ʋ̩̄ă̩	ʋ̩̄ă̩	uːa	1	diphthong	from long rounded close back to unrounded open front diphthong
+ḕè̱	ḕè̱	ɛːɛ	1	diphthong	from long unrounded open-mid front to unrounded open-mid front diphthong
+ŭ̀a̱	ŭ̀a̱	ʏa	1	diphthong	from rounded near-close near-front to unrounded open front diphthong
+ū̀ȧ̱	ū̀ȧ̱	ʏːɐ	1	diphthong	from long rounded near-close near-front to unrounded near-open central diphthong
+ʋ͜ắ	ʋ͜ắ	ua	1	diphthong	from rounded close back to unrounded open front diphthong
+oͮ͜a	oͮ͜a	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+ʋ̄ȧ̱	ʋ̄ȧ̱	uːɐ	1	diphthong	from long rounded close back to unrounded near-open central diphthong
+ēë̱	ēë̱	eːɛ	1	diphthong	from long unrounded close-mid front to unrounded open-mid front diphthong
+ăè	ăè	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+aė̱	aė̱	aə	1	diphthong	from unrounded open front to unrounded mid central diphthong
+t̮̄	t̮̄	tʲ	2	consonant	palatalized voiceless alveolar stop consonant
+iȯ̱	iȯ̱	iɔ	1	diphthong	from unrounded close front to rounded open-mid back diphthong
+a̱è	a̱è	aɛ	3	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ŏ̩́	ŏ̩́	o	2	vowel	rounded close-mid back vowel
+ṉ̇͜	ṉ̇͜	ŋ	1	consonant	voiced velar nasal consonant
+ãò̃	ãò̃	ãɔ̃	3	diphthong	from nasalized unrounded open front to nasalized rounded open-mid back diphthong
+aͦ̃͜é̃	aͦ̃͜é̃	ɑẽ	2	diphthong	from unrounded open back to nasalized unrounded close-mid front diphthong
+īa̱ͦ	īa̱ͦ	iːɒ	1	diphthong	from long unrounded close front to rounded open back diphthong
+uè	uè	yɛ	2	diphthong	from rounded close front to unrounded open-mid front diphthong
+ă͜ĕ́	ă͜ĕ́	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ūè	ūè	ỹːɛ	3	diphthong	from long nasalized rounded close front to unrounded open-mid front diphthong
+uĕ̀	uĕ̀	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+ū̀è̱	ū̀è̱	ʏːɛ	1	diphthong	from long rounded near-close near-front to unrounded open-mid front diphthong
+i͋	i͋	i	1	vowel	unrounded close front vowel
+ʋ̩̆è̩	ʋ̩̆è̩	uɛ	1	diphthong	from rounded close back to unrounded open-mid front diphthong
+i̩è̱	i̩è̱	ɪɛ	2	diphthong	from unrounded near-close near-front to unrounded open-mid front diphthong
+a͜ʋ	a͜ꭒ	au	1	diphthong	from unrounded open front to rounded close back diphthong
+u̩è	u̩è	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+èĩ̱	èĩ̱	ɛi	1	diphthong	from unrounded open-mid front to unrounded close front diphthong
+ṓë̱	ṓë̱	oːɛ	2	diphthong	from long rounded close-mid back to unrounded open-mid front diphthong
+ʋ̆͜	ʋ̆͜	u	4	vowel	rounded close back vowel
+ʋ̆ă	ʋ̆ă	ua	1	diphthong	from rounded close back to unrounded open front diphthong
+óè	óè	oɛ	1	diphthong	from rounded close-mid back to unrounded open-mid front diphthong
+ʋë̱	ꭒë̱	uɛ	1	diphthong	from rounded close back to unrounded open-mid front diphthong
+ʋȯ̱	ꭒȯ̱	uɔ	1	diphthong	from rounded close back to rounded open-mid back diphthong
+i̩è	i̩è	ɪɛ	1	diphthong	from unrounded near-close near-front to unrounded open-mid front diphthong
+ì̩a	ì̩a	ɪa	1	diphthong	from unrounded near-close near-front to unrounded open front diphthong
+ė͋	ė͋	e	1	vowel	unrounded close-mid front vowel
+a̱͜aͤ̄	a̱͜aͤ̄	aæː	1	diphthong	from unrounded open front to long unrounded near-open front diphthong
+ā͜é	ā͜é	aːe	1	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ăĕ́	ăĕ́	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ia	ia	ia	1	diphthong	from unrounded close front to unrounded open front diphthong
+o͜ĭ	o͜ĭ	oɪ	1	diphthong	from rounded close-mid back to unrounded near-close near-front diphthong
+a̱ͦ̃è̃	a̱ͦ̃è̃	ɒɛ̃	2	diphthong	from rounded open back to nasalized unrounded open-mid front diphthong
+īë	īë	iːɛ	1	diphthong	from long unrounded close front to unrounded open-mid front diphthong
+iè̱	iè̱	iɛ	3	diphthong	from unrounded close front to unrounded open-mid front diphthong
+ă̩ó	ă̩ó	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+ŏ̩̀ĭ	ŏ̩̀ĭ	ɔɪ	3	diphthong	from rounded open-mid back to unrounded near-close near-front diphthong
+t̄	t̄	tː	4	consonant	long voiceless alveolar stop consonant
+ẽ̩ĩ̱	ẽ̩ĩ̱	ei	2	diphthong	from unrounded close-mid front to unrounded close front diphthong
+è̩i̱	è̩i̱	ɛi	1	diphthong	from unrounded open-mid front to unrounded close front diphthong
+a̱ͤè̃	a̱ͤè̃	æɛ̃	1	diphthong	from unrounded near-open front to nasalized unrounded open-mid front diphthong
+ằĕ̀	ằĕ̀	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ẽi̱	ẽi̱	ẽi	1	diphthong	from nasalized unrounded close-mid front to unrounded close front diphthong
+œ́̃	œ́̃	ø̃	1	vowel	nasalized rounded close-mid front vowel
+oͮ̄o̱ͮ	oͮ̄o̱ͮ	oːo	2	diphthong	from long rounded close-mid back to rounded close-mid back diphthong
+ʋ̄̀ė̱	ʋ̄̀ė̱	ʊːə	3	diphthong	from long rounded near-close near-back to unrounded mid central diphthong
+ū̀ė̱	ū̀ė̱	ʏːə	1	diphthong	from long rounded near-close near-front to unrounded mid central diphthong
+œ̱̀i	œ̱̀i	œi	2	diphthong	from rounded open-mid front to unrounded close front diphthong
+ʋ͜	ʋ͜	u	7	vowel	rounded close back vowel
+ă̩oͮ	ă̩oͮ	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+ṟ̇	ṟ̇	ʀ	2	consonant	voiced uvular trill consonant
+oʋ̱̆	oʋ̱̆	ou	1	diphthong	from rounded close-mid back to rounded close back diphthong
+a̱̩ͤ͜ó	a̱̩ͤ͜ó	æo	2	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ò̱̩œ̄	ò̱̩œ̄	ɔøː	2	diphthong	from rounded open-mid back to long rounded close-mid front diphthong
+a̱͜ō	a̱͜ō	aoː	1	diphthong	from unrounded open front to long rounded close-mid back diphthong
+m̄	m̄	mː	9	consonant	long voiced bilabial nasal consonant
+õ̩	õ̩	o	1	vowel	rounded close-mid back vowel
+a̩ͦ̃	a̩ͦ̃	ɑ	2	vowel	unrounded open back vowel
+ă̩ò̱	ă̩ò̱	aɔ	1	diphthong	from unrounded open front to rounded open-mid back diphthong
+a̩ò	a̩ò	aɔ	1	diphthong	from unrounded open front to rounded open-mid back diphthong
+a̩ͦ̄ò̱	a̩ͦ̄ò̱	ɑːɔ	1	diphthong	from long unrounded open back to rounded open-mid back diphthong
+a̩ò̱	a̩ò̱	aɔ	1	diphthong	from unrounded open front to rounded open-mid back diphthong
+œ̆̀u	œ̆̀u	œy	3	diphthong	from rounded open-mid front to rounded close front diphthong
+ò̱œ̄̀	ò̱œ̄̀	ɔœː	4	diphthong	from rounded open-mid back to long rounded open-mid front diphthong
+á̩	á̩	ɑ	1	vowel	unrounded open back vowel
+aͤó	aͤó	æo	4	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+a̱ͤ	a̱ͤ	æ	2	vowel	unrounded near-open front vowel
+l̮à̃	l̮ à̃	l ã	8	unknownsound	
+yà̃	y à̃	j ã	6	unknownsound	
+ò̱̃	ò̱̃	ɔ̃	2	vowel	nasalized rounded open-mid back vowel
+œ̱ó	œ̱ó	øo	2	diphthong	from rounded close-mid front to rounded close-mid back diphthong
+a̱ͦ͜è̃	a̱ͦ͜è̃	ɒɛ̃	1	diphthong	from rounded open back to nasalized unrounded open-mid front diphthong
+ăoͮ̆	ăoͮ̆	ao	2	diphthong	from unrounded open front to rounded close-mid back diphthong
+ăyă͜ó̱	ă y ă͜ó̱	a j ao	2	unknownsound	
+a̱é̃	a̱é̃	aẽ	1	diphthong	from unrounded open front to nasalized unrounded close-mid front diphthong
+ãè̃	ãè̃	ãɛ̃	2	diphthong	from nasalized unrounded open front to nasalized unrounded open-mid front diphthong
+ăā	ăā	aː	1	vowel	long unrounded open front vowel
+a̱ͦ̃é̃	a̱ͦ̃é̃	ɒẽ	1	diphthong	from rounded open back to nasalized unrounded close-mid front diphthong
+ẕ	ẕ	z	1	consonant	voiced alveolar sibilant fricative consonant
+ië̱	ië̱	iɛ	4	diphthong	from unrounded close front to unrounded open-mid front diphthong
+a̱͜è̃	a̱͜è̃	aɛ̃	2	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+ã̱ẽ	ã̱ẽ	aẽ	2	diphthong	from unrounded open front to nasalized unrounded close-mid front diphthong
+œ̆̀ṓ	œ̆̀ṓ	œoː	1	diphthong	from rounded open-mid front to long rounded close-mid back diphthong
+a͜e̱ͥ	a͜e̱ͥ	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+ȯ̱ʋ̃	ȯ̱ʋ̃	ɔũ	1	diphthong	from rounded open-mid back to nasalized rounded close back diphthong
+œ̄́ù̱	œ̄́ù̱	øːʏ	1	diphthong	from long rounded close-mid front to rounded near-close near-front diphthong
+aͤ̄oͮ	aͤ̄oͮ	æːo	1	diphthong	from long unrounded near-open front to rounded close-mid back diphthong
+ṑœ̱̀	ṑœ̱̀	ɔːœ	1	diphthong	from long rounded open-mid back to rounded open-mid front diphthong
+uͨœ	uͨœ	yø	1	diphthong	from rounded close front to rounded close-mid front diphthong
+u̱̇	u̱̇	ʏ	8	vowel	rounded near-close near-front vowel
+ã̱ò̱̃	ã̱ò̱̃	aɔ	1	diphthong	from unrounded open front to rounded open-mid back diphthong
+è̱̩	è̱̩	e	2	vowel	unrounded close-mid front vowel
+œ̱̀ó	œ̱̀ó	œo	2	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+aè̃	aè̃	aɛ̃	1	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+ĭ̱	ĭ̱	i	1	vowel	unrounded close front vowel
+œ̀͜i	œ̀͜i	œi	1	diphthong	from rounded open-mid front to unrounded close front diphthong
+o̩ͮ	o̩ͮ	o	2	vowel	rounded close-mid back vowel
+c̵̯	c̵̯	ʃ	2	consonant	voiceless post-alveolar sibilant fricative consonant
+ḕa	ḕa	ɛːa	3	diphthong	from long unrounded open-mid front to unrounded open front diphthong
+œ̆̀o̱	œ̆̀o̱	œo	1	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+œ̱̀ū̀	œ̱̀ū̀	œʏː	1	diphthong	from rounded open-mid front to long rounded near-close near-front diphthong
+ȯ̱͜œ̩̄	ȯ̱͜œ̩̄	ɔøː	1	diphthong	from rounded open-mid back to long rounded close-mid front diphthong
+œ̩	œ̩	ø	1	vowel	rounded close-mid front vowel
+ūò̃	ūò̃	ỹːɔ̃	1	diphthong	from long nasalized rounded close front to nasalized rounded open-mid back diphthong
+ă̩ĭ	ă̩ĭ	aɪ	1	diphthong	from unrounded open front to unrounded near-close near-front diphthong
+ăeͥ	ăeͥ	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+āĕ	āĕ	aːe	1	diphthong	from long unrounded open front to unrounded close-mid front diphthong
+ẓ̱	ẓ̱	ð	3	consonant	voiced dental fricative consonant
+ė̱ã	ė̱ã	əã	1	diphthong	from unrounded mid central to nasalized unrounded open front diphthong
+aͦ̃͜è̃	aͦ̃͜è̃	ɑɛ̃	4	diphthong	from unrounded open back to nasalized unrounded open-mid front diphthong
+aͤ̄è̱̃	aͤ̄è̱̃	æːɛ	2	diphthong	from long unrounded near-open front to unrounded open-mid front diphthong
+i͜ė	i͜ė	iə	1	diphthong	from unrounded close front to unrounded mid central diphthong
+a̱͜aͤ	a̱͜aͤ	aæ	1	diphthong	from unrounded open front to unrounded near-open front diphthong
+āò	āò	aːɔ	3	diphthong	from long unrounded open front to rounded open-mid back diphthong
+ò̱͜eͥ̆	ò̱͜eͥ̆	ɔe	1	diphthong	from rounded open-mid back to unrounded close-mid front diphthong
+aò̃	aò̃	aɔ̃	1	diphthong	from unrounded open front to nasalized rounded open-mid back diphthong
+ãé̱̃	ãé̱̃	ãe	1	diphthong	from nasalized unrounded open front to unrounded close-mid front diphthong
+è̱͜ã	è̱͜ã	ɛã	1	diphthong	from unrounded open-mid front to nasalized unrounded open front diphthong
+œ̱̀͜ò̃	œ̱̀͜ò̃	œɔ̃	1	diphthong	from rounded open-mid front to nasalized rounded open-mid back diphthong
+ăʋ̆	ăʋ̆	au	2	diphthong	from unrounded open front to rounded close back diphthong
+āo̱͜è	āo̱͜ è	aːo ɛ	1	unknownsound	
+è͜i̱	è͜i̱	ɛi	1	diphthong	from unrounded open-mid front to unrounded close front diphthong
+ăe	ăe	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+è̱ē	è̱ē	ɛeː	1	diphthong	from unrounded open-mid front to long unrounded close-mid front diphthong
+ŏ̀ĭ	ŏ̀ĭ	ɔɪ	3	diphthong	from rounded open-mid back to unrounded near-close near-front diphthong
+aó̱̃	aó̱̃	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+ā̩o̱	ā̩o̱	aːo	1	diphthong	from long unrounded open front to rounded close-mid back diphthong
+aõ̱	aõ̱	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+āò̃	āò̃	aːɔ̃	2	diphthong	from long unrounded open front to nasalized rounded open-mid back diphthong
+ȯ̱̃	ȯ̱̃	ɔ	1	vowel	rounded open-mid back vowel
+aͦò̱	aͦò̱	ɒɔ	1	diphthong	from rounded open back to rounded open-mid back diphthong
+ʋ̀̃ė̱̃	ʋ̀̃ė̱̃	ʊ̃ə	3	diphthong	from nasalized rounded near-close near-back to unrounded mid central diphthong
+à̄̃	à̄̃	ãː	1	vowel	long nasalized unrounded open front vowel
+œ́ù̱	œ́ù̱	øʏ	1	diphthong	from rounded close-mid front to rounded near-close near-front diphthong
+œ͜ó	œ͜ó	øo	1	diphthong	from rounded close-mid front to rounded close-mid back diphthong
+œ̀͜ó	œ̀͜ó	œo	3	diphthong	from rounded open-mid front to rounded close-mid back diphthong
+ė̱ṑ	ė̱ṑ	əɔː	1	diphthong	from unrounded mid central to long rounded open-mid back diphthong
+œͦ	œͦ	ɞ	2	vowel	rounded open-mid central vowel
+aͦ̄ʋ̱	aͦ̄ʋ̱	ɒːu	1	diphthong	from long rounded open back to rounded close back diphthong
+ăò̱	ăò̱	aɔ	2	diphthong	from unrounded open front to rounded open-mid back diphthong
+a̩ͦè̱	a̩ͦè̱	ɑɛ	1	diphthong	from unrounded open back to unrounded open-mid front diphthong
+ie	ie	ie	1	diphthong	from unrounded close front to unrounded close-mid front diphthong
+ĕī	ĕī	eiː	1	diphthong	from unrounded close-mid front to long unrounded close front diphthong
+ĕ̀ḗ	ĕ̀ḗ	ɛeː	2	diphthong	from unrounded open-mid front to long unrounded close-mid front diphthong
+ĕ̀ē	ĕ̀ē	ɛeː	1	diphthong	from unrounded open-mid front to long unrounded close-mid front diphthong
+ĕḗ	ĕḗ	eː	1	vowel	long unrounded close-mid front vowel
+a̩͜é	a̩͜é	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+oͮ̄ė̱	oͮ̄ė̱	oːə	1	diphthong	from long rounded close-mid back to unrounded mid central diphthong
+ṓè̱	ṓè̱	oːɛ	1	diphthong	from long rounded close-mid back to unrounded open-mid front diphthong
+ĭ̩̀	ĭ̩̀	ɪ	1	vowel	unrounded near-close near-front vowel
+ắo	ắo	ɑo	1	diphthong	from unrounded open back to rounded close-mid back diphthong
+œ̩̀u̱	œ̩̀u̱	œy	1	diphthong	from rounded open-mid front to rounded close front diphthong
+é͜i̱	é͜i̱	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ŏ̀ë	ŏ̀ë	ɔɛ	1	diphthong	from rounded open-mid back to unrounded open-mid front diphthong
+ŏĕ̀	ŏĕ̀	oɛ	1	diphthong	from rounded close-mid back to unrounded open-mid front diphthong
+i̩ṑ	i̩ṑ	ɪɔː	1	diphthong	from unrounded near-close near-front to long rounded open-mid back diphthong
+ia͜ó̱	i a͜ó̱	i ao	1	unknownsound	
+yò͜ó̱	y ò͜ó̱	j ɔo	1	unknownsound	
+ʋ̆ò	ʋ̆ò	uɔ	1	diphthong	from rounded close back to rounded open-mid back diphthong
+œu	œu	øy	3	diphthong	from rounded close-mid front to rounded close front diphthong
+ȯ̱ʋ̄̀	ȯ̱ʋ̄̀	ɔʊː	1	diphthong	from rounded open-mid back to long rounded near-close near-back diphthong
+œ̱̀ṑ	œ̱̀ṑ	œɔː	1	diphthong	from rounded open-mid front to long rounded open-mid back diphthong
+ĕ́ë̱	ĕ́ë̱	eɛ	1	diphthong	from unrounded close-mid front to unrounded open-mid front diphthong
+^dj͛yŏ̀	dj͛ y ŏ̀	dʒ j ɔ	1	unknownsound	
+i̩ò	i̩ò	ɪɔ	1	diphthong	from unrounded near-close near-front to rounded open-mid back diphthong
+ăʋ̱̀	ăʋ̱̀	aʊ	2	diphthong	from unrounded open front to rounded near-close near-back diphthong
+ʋ̆ė̱	ʋ̆ė̱	uə	1	diphthong	from rounded close back to unrounded mid central diphthong
+ŏʋ̱	ŏʋ̱	ou	4	diphthong	from rounded close-mid back to rounded close back diphthong
+a̩ṓ	a̩ṓ	aoː	1	diphthong	from unrounded open front to long rounded close-mid back diphthong
+ʋè̩	ꭒè̩	uɛ	1	diphthong	from rounded close back to unrounded open-mid front diphthong
+aͤ͜ó̩	aͤ͜ó̩	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ò̱œ̩̄	ò̱œ̩̄	ɔøː	1	diphthong	from rounded open-mid back to long rounded close-mid front diphthong
+aͤì̱	aͤì̱	æɪ	1	diphthong	from unrounded near-open front to unrounded near-close near-front diphthong
+ʋ̀̃ė̱	ʋ̀̃ė̱	ʊ̃ə	1	diphthong	from nasalized rounded near-close near-back to unrounded mid central diphthong
+œͧu̱	œͧu̱	øy	1	diphthong	from rounded close-mid front to rounded close front diphthong
+ūœ̱́	ūœ̱́	ỹːø	1	diphthong	from long nasalized rounded close front to rounded close-mid front diphthong
+è̱ā̩̃	è̱ā̩̃	ɛãː	1	diphthong	from unrounded open-mid front to long nasalized unrounded open front diphthong
+à̩̃	à̩̃	ã	2	vowel	nasalized unrounded open front vowel
+ë̆	ë̆	ɛ	1	vowel	unrounded open-mid front vowel
+œ̱̀͜ṓ̩	œ̱̀͜ṓ̩	œoː	1	diphthong	from rounded open-mid front to long rounded close-mid back diphthong
+ã̱͜è̃	ã̱͜è̃	aɛ̃	2	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+u͜ā̩	u͜ā̩	yaː	1	diphthong	from rounded close front to long unrounded open front diphthong
+ʋ̆ó	ʋ̆ó	uo	1	diphthong	from rounded close back to rounded close-mid back diphthong
+ʋ̆ā	ʋ̆ā	uaː	3	diphthong	from rounded close back to long unrounded open front diphthong
+ò͜ā	ò͜ā	ɔaː	1	diphthong	from rounded open-mid back to long unrounded open front diphthong
+ŏ̀ŏ́	ŏ̀ŏ́	ɔo	1	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+u͜āyė̱	u͜ā y ė̱	yaː j ə	1	unknownsound	
+ò͜āè	ò͜ā è	ɔaː ɛ	1	unknownsound	
+ò͜āè̱	ò͜ā è̱	ɔaː ɛ	1	unknownsound	
+īé̱	īé̱	iːe	1	diphthong	from long unrounded close front to unrounded close-mid front diphthong
+ʋ̱̄	ʋ̱̄	uː	9	vowel	long rounded close back vowel
+ė̱oͮ̄	ė̱oͮ̄	əoː	1	diphthong	from unrounded mid central to long rounded close-mid back diphthong
+oͮ̆ʋ̱̄	oͮ̆ʋ̱̄	ouː	1	diphthong	from rounded close-mid back to long rounded close back diphthong
+ŏ́ʋ̱̄	ŏ́ʋ̱̄	ouː	2	diphthong	from rounded close-mid back to long rounded close back diphthong
+ʋ̱̀	ʋ̱̀	ʊ	4	vowel	rounded near-close near-back vowel
+òʋ̱̄	òʋ̱̄	ɔuː	1	diphthong	from rounded open-mid back to long rounded close back diphthong
+īè	īè	iːɛ	1	diphthong	from long unrounded close front to unrounded open-mid front diphthong
+œ̩̄	œ̩̄	øː	1	vowel	long rounded close-mid front vowel
+ò͋	ò͋	ɔ	1	vowel	rounded open-mid back vowel
+ėʋ̃	ėʋ̃	əũ	1	diphthong	from unrounded mid central to nasalized rounded close back diphthong
+ėo̱	ėo̱	əo	1	diphthong	from unrounded mid central to rounded close-mid back diphthong
+ă̱ó̃	ă̱ó̃	aõ	1	diphthong	from unrounded open front to nasalized rounded close-mid back diphthong
+ʋ̩̀̃	ʋ̩̀̃	ʊ̃	1	vowel	nasalized rounded near-close near-back vowel
+œ̄́ė̱	œ̄́ė̱	øːə	1	diphthong	from long rounded close-mid front to unrounded mid central diphthong
+uͨ̆u̱	uͨ̆u̱	yː	1	vowel	long rounded close front vowel
+aͤ̆͜ó	aͤ̆͜ó	æo	1	diphthong	from unrounded near-open front to rounded close-mid back diphthong
+ṑu̱	ṑu̱	ɔːy	1	diphthong	from long rounded open-mid back to rounded close front diphthong
+ḗ̩i̱	ḗ̩i̱	eːi	1	diphthong	from long unrounded close-mid front to unrounded close front diphthong
+u̱	u̱	y	1	vowel	rounded close front vowel
+ō̱	ō̱	oː	1	vowel	long rounded close-mid back vowel
+ó̩̃	ó̩̃	o	1	vowel	rounded close-mid back vowel
+ḕȧ̱	ḕȧ̱	ɛːɐ	1	diphthong	from long unrounded open-mid front to unrounded near-open central diphthong
+ă̩é̱	ă̩é̱	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+īȯ̱	īȯ̱	iːɔ	1	diphthong	from long unrounded close front to rounded open-mid back diphthong
+òŏ́	òŏ́	ɔo	1	diphthong	from rounded open-mid back to rounded close-mid back diphthong
+é̃ĩ	é̃ĩ	ẽɪ̃	3	diphthong	from nasalized unrounded close-mid front to nasalized unrounded near-close near-front diphthong
+é̩̃ĩ̱	é̩̃ĩ̱	ẽi	1	diphthong	from nasalized unrounded close-mid front to unrounded close front diphthong
+è̩̃ĩ	è̩̃ĩ	ɛ̃ɪ̃	1	diphthong	from nasalized unrounded open-mid front to nasalized unrounded near-close near-front diphthong
+aͦó	aͦó	ɒo	1	diphthong	from rounded open back to rounded close-mid back diphthong
+œ̆́͜u̱	œ̆́͜u̱	øy	1	diphthong	from rounded close-mid front to rounded close front diphthong
+œͦ̄ʋ̱ͧ	œͦ̄ʋ̱ͧ	ɞːʉ	1	diphthong	from long rounded open-mid central to rounded close central diphthong
+œ́œ̱̃	œ́œ̱̃	øː	1	vowel	long rounded close-mid front vowel
+ĩė̱	ĩė̱	ɪ̃ə	1	diphthong	from nasalized unrounded near-close near-front to unrounded mid central diphthong
+c̱̑	c̱̑	x	1	consonant	voiceless velar fricative consonant
+ė̱̩	ė̱̩	ə	3	vowel	unrounded mid central vowel
+è̱ā̃	è̱ā̃	ɛãː	3	diphthong	from unrounded open-mid front to long nasalized unrounded open front diphthong
+ò̱ṓ	ò̱ṓ	ɔoː	1	diphthong	from rounded open-mid back to long rounded close-mid back diphthong
+ò͜aͦ̄	ò͜aͦ̄	ɔɒː	1	diphthong	from rounded open-mid back to long rounded open back diphthong
+ŏ̩́ă̩	ŏ̩́ă̩	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+ṓė	ṓė	oːə	1	diphthong	from long rounded close-mid back to unrounded mid central diphthong
+ŏ́ė̱	ŏ́ė̱	oə	1	diphthong	from rounded close-mid back to unrounded mid central diphthong
+ā̀ò̱	ā̀ò̱	aːɔ	1	diphthong	from long unrounded open front to rounded open-mid back diphthong
+a̩ͤi	a̩ͤi	æi	1	diphthong	from unrounded near-open front to unrounded close front diphthong
+ĕi	ĕi	ei	4	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ă̩ḕ̱	ă̩ḕ̱	aɛː	1	diphthong	from unrounded open front to long unrounded open-mid front diphthong
+òi	òi	ɔi	1	diphthong	from rounded open-mid back to unrounded close front diphthong
+ė̱ė̃	ė̱ė̃	ə̃ː	1	vowel	long nasalized unrounded mid central vowel
+ĕ̩i̱	ĕ̩i̱	ei	2	diphthong	from unrounded close-mid front to unrounded close front diphthong
+īė̱̃	īė̱̃	iːə	1	diphthong	from long unrounded close front to unrounded mid central diphthong
+ã͜è̃	ã͜è̃	ãɛ̃	1	diphthong	from nasalized unrounded open front to nasalized unrounded open-mid front diphthong
+è̱aͤ̃	è̱aͤ̃	ɛæ̃	1	diphthong	from unrounded open-mid front to nasalized unrounded near-open front diphthong
+è̱̃ã	è̱̃ã	ɛã	1	diphthong	from unrounded open-mid front to nasalized unrounded open front diphthong
+t̄s	t̄s	tsː	1	consonant	long voiceless alveolar sibilant affricate consonant
+yà̱	y à̱	j a	1	unknownsound	
+é͜i	é͜i	ei	2	diphthong	from unrounded close-mid front to unrounded close front diphthong
+à̩	à̩	a	1	vowel	unrounded open front vowel
+gͩ	gͩ	g	3	consonant	voiced velar stop consonant
+a̱ò	a̱ò	aɔ	3	diphthong	from unrounded open front to rounded open-mid back diphthong
+a̱ó͜ʋ̱	a̱ ó͜ʋ̱	a ou	1	unknownsound	
+a̩͜ó̱	a̩͜ó̱	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+ò̱̩œ̩̄	ò̱̩œ̩̄	ɔøː	1	diphthong	from rounded open-mid back to long rounded close-mid front diphthong
+ò̱ṑ	ò̱ṑ	ɔː	1	vowel	long rounded open-mid back vowel
+ŏ̩̀œ̆̀	ŏ̩̀œ̆̀	ɔœ	1	diphthong	from rounded open-mid back to rounded open-mid front diphthong
+œʋ̱ͧ	œʋ̱ͧ	øʉ	1	diphthong	from rounded close-mid front to rounded close central diphthong
+z̄	z̄	zː	1	consonant	long voiced alveolar sibilant fricative consonant
+ū̩ė	ū̩ė	ʏə	1	diphthong	from rounded near-close near-front to unrounded mid central diphthong
+è̱è̃	è̱è̃	ɛ̃ː	1	vowel	long nasalized unrounded open-mid front vowel
+a̱é	a̱é	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+a̩ʋ̆	a̩ʋ̆	au	1	diphthong	from unrounded open front to rounded close back diphthong
+oͮ̄ó̱	oͮ̄ó̱	oːo	1	diphthong	from long rounded close-mid back to rounded close-mid back diphthong
+uͨ̄ă	uͨ̄ă	yːa	1	diphthong	from long rounded close front to unrounded open front diphthong
+œ̄ė̱	œ̄ė̱	øːə	1	diphthong	from long rounded close-mid front to unrounded mid central diphthong
+ăḗ̩	ăḗ̩	aeː	1	diphthong	from unrounded open front to long unrounded close-mid front diphthong
+ʋ̄é̱	ʋ̄é̱	uːe	1	diphthong	from long rounded close back to unrounded close-mid front diphthong
+ȯ̱̩ʋ̄̀	ȯ̱̩ʋ̄̀	ɔʊː	1	diphthong	from rounded open-mid back to long rounded near-close near-back diphthong
+ʋ̀ė̱	ʋ̀ė̱	ʊə	2	diphthong	from rounded near-close near-back to unrounded mid central diphthong
+à̱è̃	à̱è̃	aɛ̃	1	diphthong	from unrounded open front to nasalized unrounded open-mid front diphthong
+e̩i̱	e̩i̱	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+é̩i̱	é̩i̱	ei	2	diphthong	from unrounded close-mid front to unrounded close front diphthong
+e̩ͥ̄	e̩ͥ̄	e	1	vowel	unrounded close-mid front vowel
+éa̱	éa̱	ea	1	diphthong	from unrounded close-mid front to unrounded open front diphthong
+aͤè̱	aͤè̱	æɛ	1	diphthong	from unrounded near-open front to unrounded open-mid front diphthong
+i͜ė̱	i͜ė̱	iə	1	diphthong	from unrounded close front to unrounded mid central diphthong
+ė̱͜é	ė̱͜é	əe	1	diphthong	from unrounded mid central to unrounded close-mid front diphthong
+ŏ̀ò̃	ŏ̀ò̃	ɔ̃ː	1	vowel	long nasalized rounded open-mid back vowel
+ūằ	ūằ	ỹːa	1	diphthong	from long nasalized rounded close front to unrounded open front diphthong
+u̩a̩	u̩a̩	ya	1	diphthong	from rounded close front to unrounded open front diphthong
+ŭ̩͜ĕ̀	ŭ̩͜ĕ̀	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+ṑò̱	ṑò̱	ɔːɔ	1	diphthong	from long rounded open-mid back to rounded open-mid back diphthong
+ṓă	ṓă	oːa	1	diphthong	from long rounded close-mid back to unrounded open front diphthong
+ṓʋ	ṓꭒ	oːu	1	diphthong	from long rounded close-mid back to rounded close back diphthong
+ŭ̩è̩	ŭ̩è̩	yɛ	1	diphthong	from rounded close front to unrounded open-mid front diphthong
+óė̱	óė̱	oə	3	diphthong	from rounded close-mid back to unrounded mid central diphthong
+œ̀i̱	œ̀i̱	œi	1	diphthong	from rounded open-mid front to unrounded close front diphthong
+eͥ̆i̱	eͥ̆i̱	ei	1	diphthong	from unrounded close-mid front to unrounded close front diphthong
+ʋ̩̄ȯ̱	ʋ̩̄ȯ̱	uːɔ	1	diphthong	from long rounded close back to rounded open-mid back diphthong
+aͤ͜œ̄̀	aͤ͜œ̄̀	æœː	1	diphthong	from unrounded near-open front to long rounded open-mid front diphthong
+ă̩oͮ̆	ă̩oͮ̆	ao	1	diphthong	from unrounded open front to rounded close-mid back diphthong
+ā̩́ĕ̀	ā̩́ĕ̀	ɑːɛ	1	diphthong	from long unrounded open back to unrounded open-mid front diphthong
+o̱͜	o̱͜	o	1	vowel	rounded close-mid back vowel
+iĕ́	iĕ́	ie	1	diphthong	from unrounded close front to unrounded close-mid front diphthong
+i͜é	i͜é	ie	1	diphthong	from unrounded close front to unrounded close-mid front diphthong
+ié	ié	ie	1	diphthong	from unrounded close front to unrounded close-mid front diphthong
+ó̩ă	ó̩ă	oa	1	diphthong	from rounded close-mid back to unrounded open front diphthong
+ȳ	ȳ	jː	1	consonant	long voiced palatal approximant consonant
+oͮʋ	oͮꭒ	ou	1	diphthong	from rounded close-mid back to rounded close back diphthong
+óè̱	óè̱	oɛ	1	diphthong	from rounded close-mid back to unrounded open-mid front diphthong
+o̱͜ā	o̱͜ā	oaː	1	diphthong	from rounded close-mid back to long unrounded open front diphthong
+āo̱͜è̱	ā o̱͜è̱	aː oɛ	1	unknownsound	
+ae	ae	ae	1	diphthong	from unrounded open front to unrounded close-mid front diphthong
+a̩ͦ̃ʋ̱̃	a̩ͦ̃ʋ̱̃	ɑu	1	diphthong	from unrounded open back to rounded close back diphthong
+è̱ȧ	è̱ȧ	ɛɐ	1	diphthong	from unrounded open-mid front to unrounded near-open central diphthong
+ằè̱	ằè̱	aɛ	1	diphthong	from unrounded open front to unrounded open-mid front diphthong
+ua	ua	ya	1	diphthong	from rounded close front to unrounded open front diphthong
+œ̱̀ṓ	œ̱̀ṓ	œoː	1	diphthong	from rounded open-mid front to long rounded close-mid back diphthong
+a̱ẽ	a̱ẽ	aẽ	1	diphthong	from unrounded open front to nasalized unrounded close-mid front diphthong
+aͦ̃͜ë̃	aͦ̃͜ë̃	ɑɛ	1	diphthong	from unrounded open back to unrounded open-mid front diphthong
+ṑi	ṑi	ɔːi	1	diphthong	from long rounded open-mid back to unrounded close front diphthong
+ė̱ằ	ė̱ằ	əa	1	diphthong	from unrounded mid central to unrounded open front diphthong
+^dj͛i	dj͛ i	dʒ i	1	unknownsound	
+^dy̓	dy̓	dʒʲ	1	consonant	palatalized voiced post-alveolar sibilant affricate consonant
+^djĭ	dj ĭ	dʒ ɪ	1	unknownsound	
+^dj͛	dj͛	dʒ	1	consonant	voiced post-alveolar sibilant affricate consonant
+a̱õ	a̱õ	aõ	1	diphthong	from unrounded open front to nasalized rounded close-mid back diphthong
+a̱ó̃	a̱ó̃	aõ	1	diphthong	from unrounded open front to nasalized rounded close-mid back diphthong


### PR DESCRIPTION
This PR does not change the original orthography data, and therefore also does not require a revision of the version 1.0 whatsoever, but it adds our clts interpretations regarding the sound classes, which seems to be important for transparency reasons and future modifications of the profile.